### PR TITLE
REPO-5405 Allow multiple event type handler

### DIFF
--- a/alfresco-java-event-api/README.md
+++ b/alfresco-java-event-api/README.md
@@ -32,13 +32,29 @@ The main four items in this library are explained in the next sections.
 contract of each implementation of a behaviour to be triggered as a reaction to an event.
 
 This contract has been reduced to a minimum, which is:
-* The type of event the handler will tackle.
+* The type(s) of event(s) the handler will tackle.
 * Other conditions the event must match to be handled (defaulted to none). See [Event Filter](#event-filter).
 * The code to execute as a reaction to the event.
 
 A hierarchy of interfaces that extend [```EventHandler```](./alfresco-java-event-api-handling/src/main/java/org/alfresco/event/sdk/handling/handler/EventHandler.java) 
 has been already defined to cover the different types of events that can be currently triggered by the API (i.e. 
 [```OnNodeDeletedEventHandler```](./alfresco-java-event-api-handling/src/main/java/org/alfresco/event/sdk/handling/handler/OnNodeDeletedEventHandler.java)).
+
+If you want to implement an [```EventHandler```](./alfresco-java-event-api-handling/src/main/java/org/alfresco/event/sdk/handling/handler/EventHandler.java) 
+that implements more than one interface in the hierarchy you will need to provide an implementation of the method ```getHandledEventTypes``` to solve the 
+conflict of default implementations of this method provided by each interface. It would be as easy as implementing the method returning a set with all the 
+event types that your handler should handle.
+
+```java
+public class MyMultipleEventTypeHandler implements OnNodeCreatedEventHandler,OnNodeUpdatedEventHandler {
+    ...
+    @Override 
+    public Set<EventType> getHandledEventTypes() {
+        return Set.of(EventType.NODE_CREATED, EventType.NODE_UPDATED);
+    }
+    ...
+}
+```
 
 #### Event Handling Registry
 

--- a/alfresco-java-event-api/alfresco-java-event-api-handling/src/main/java/org/alfresco/event/sdk/handling/EventHandlingRegistry.java
+++ b/alfresco-java-event-api/alfresco-java-event-api-handling/src/main/java/org/alfresco/event/sdk/handling/EventHandlingRegistry.java
@@ -57,13 +57,10 @@ public class EventHandlingRegistry {
 
     private void registerHandler(final EventHandler eventHandler) {
         LOGGER.debug("Registering event handler {}", eventHandler);
-        final EventType handledEventType = eventHandler.getHandledEventType();
-        if (handledEventType != null) {
+        eventHandler.getHandledEventTypes().forEach(handledEventType -> {
             final List<EventHandler> typedEventHandlers = eventHandlers.getOrDefault(handledEventType.getType(), new ArrayList<>());
             typedEventHandlers.add(eventHandler);
             eventHandlers.put(handledEventType.getType(), typedEventHandlers);
-        } else {
-            LOGGER.warn("Skipping registry of event handler {} because the event type handled is null", eventHandler);
-        }
+        });
     }
 }

--- a/alfresco-java-event-api/alfresco-java-event-api-handling/src/main/java/org/alfresco/event/sdk/handling/handler/EventHandler.java
+++ b/alfresco-java-event-api/alfresco-java-event-api-handling/src/main/java/org/alfresco/event/sdk/handling/handler/EventHandler.java
@@ -21,12 +21,15 @@ import org.alfresco.event.sdk.model.v1.model.EventType;
 import org.alfresco.event.sdk.model.v1.model.RepoEvent;
 import org.alfresco.event.sdk.model.v1.model.Resource;
 
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * Interface that declares the operations of a repo event handler.
  * <p>
  * An event handler will be triggered (the method <code>handleEvent</code> will be executed) when:
  * <ul>
- *     <li>The event type matches with the one returned by the method <code>getHandledEventType</code></li>
+ *     <li>The event type matches with the one of the returned by the method <code>getHandledEventTypes</code></li>
  *     <li>The event fulfills the conditions specified by the {@link EventFilter} returned by the method <code>getEventFilter</code></li>
  * </ul>
  * <p>
@@ -36,11 +39,11 @@ import org.alfresco.event.sdk.model.v1.model.Resource;
 public interface EventHandler {
 
     /**
-     * Obtain the {@link EventType} that this handler will handle.
+     * Obtain the set of {@link EventType}'s that this handler will handle.
      *
-     * @return the {@link EventType} handled by this handler. Ths value must not be <code>null</code>
+     * @return the set of {@link EventType}'s handled by this handler. Ths value must not be <code>null</code>
      */
-    EventType getHandledEventType();
+    Set<EventType> getHandledEventTypes();
 
     /**
      * Obtain the {@link EventFilter} that any event must fulfill to be handled by this handler.

--- a/alfresco-java-event-api/alfresco-java-event-api-handling/src/main/java/org/alfresco/event/sdk/handling/handler/OnChildAssocCreatedEventHandler.java
+++ b/alfresco-java-event-api/alfresco-java-event-api-handling/src/main/java/org/alfresco/event/sdk/handling/handler/OnChildAssocCreatedEventHandler.java
@@ -17,13 +17,15 @@ package org.alfresco.event.sdk.handling.handler;
 
 import org.alfresco.event.sdk.model.v1.model.EventType;
 
+import java.util.Set;
+
 /**
  * {@link EventHandler} for parent-child association creation handling.
  */
 @FunctionalInterface
 public interface OnChildAssocCreatedEventHandler extends ChildAssocEventHandler {
 
-    default EventType getHandledEventType() {
-        return EventType.CHILD_ASSOC_CREATED;
+    default Set<EventType> getHandledEventTypes() {
+        return Set.of(EventType.CHILD_ASSOC_CREATED);
     }
 }

--- a/alfresco-java-event-api/alfresco-java-event-api-handling/src/main/java/org/alfresco/event/sdk/handling/handler/OnChildAssocDeletedEventHandler.java
+++ b/alfresco-java-event-api/alfresco-java-event-api-handling/src/main/java/org/alfresco/event/sdk/handling/handler/OnChildAssocDeletedEventHandler.java
@@ -17,13 +17,15 @@ package org.alfresco.event.sdk.handling.handler;
 
 import org.alfresco.event.sdk.model.v1.model.EventType;
 
+import java.util.Set;
+
 /**
  * {@link EventHandler} for parent-child association deletion handling.
  */
 @FunctionalInterface
 public interface OnChildAssocDeletedEventHandler extends ChildAssocEventHandler {
 
-    default EventType getHandledEventType() {
-        return EventType.CHILD_ASSOC_DELETED;
+    default Set<EventType> getHandledEventTypes() {
+        return Set.of(EventType.CHILD_ASSOC_DELETED);
     }
 }

--- a/alfresco-java-event-api/alfresco-java-event-api-handling/src/main/java/org/alfresco/event/sdk/handling/handler/OnNodeCreatedEventHandler.java
+++ b/alfresco-java-event-api/alfresco-java-event-api-handling/src/main/java/org/alfresco/event/sdk/handling/handler/OnNodeCreatedEventHandler.java
@@ -17,13 +17,15 @@ package org.alfresco.event.sdk.handling.handler;
 
 import org.alfresco.event.sdk.model.v1.model.EventType;
 
+import java.util.Set;
+
 /**
  * {@link EventHandler} for node creation handling.
  */
 @FunctionalInterface
 public interface OnNodeCreatedEventHandler extends NodeEventHandler {
 
-    default EventType getHandledEventType() {
-        return EventType.NODE_CREATED;
+    default Set<EventType> getHandledEventTypes() {
+        return Set.of(EventType.NODE_CREATED);
     }
 }

--- a/alfresco-java-event-api/alfresco-java-event-api-handling/src/main/java/org/alfresco/event/sdk/handling/handler/OnNodeDeletedEventHandler.java
+++ b/alfresco-java-event-api/alfresco-java-event-api-handling/src/main/java/org/alfresco/event/sdk/handling/handler/OnNodeDeletedEventHandler.java
@@ -17,13 +17,15 @@ package org.alfresco.event.sdk.handling.handler;
 
 import org.alfresco.event.sdk.model.v1.model.EventType;
 
+import java.util.Set;
+
 /**
  * {@link EventHandler} for node deletion handling.
  */
 @FunctionalInterface
 public interface OnNodeDeletedEventHandler extends NodeEventHandler {
 
-    default EventType getHandledEventType() {
-        return EventType.NODE_DELETED;
+    default Set<EventType> getHandledEventTypes() {
+        return Set.of(EventType.NODE_DELETED);
     }
 }

--- a/alfresco-java-event-api/alfresco-java-event-api-handling/src/main/java/org/alfresco/event/sdk/handling/handler/OnNodeUpdatedEventHandler.java
+++ b/alfresco-java-event-api/alfresco-java-event-api-handling/src/main/java/org/alfresco/event/sdk/handling/handler/OnNodeUpdatedEventHandler.java
@@ -17,13 +17,15 @@ package org.alfresco.event.sdk.handling.handler;
 
 import org.alfresco.event.sdk.model.v1.model.EventType;
 
+import java.util.Set;
+
 /**
  * {@link EventHandler} for node update handling.
  */
 @FunctionalInterface
 public interface OnNodeUpdatedEventHandler extends NodeEventHandler {
 
-    default EventType getHandledEventType() {
-        return EventType.NODE_UPDATED;
+    default Set<EventType> getHandledEventTypes() {
+        return Set.of(EventType.NODE_UPDATED);
     }
 }

--- a/alfresco-java-event-api/alfresco-java-event-api-handling/src/main/java/org/alfresco/event/sdk/handling/handler/OnPeerAssocCreatedEventHandler.java
+++ b/alfresco-java-event-api/alfresco-java-event-api-handling/src/main/java/org/alfresco/event/sdk/handling/handler/OnPeerAssocCreatedEventHandler.java
@@ -17,13 +17,15 @@ package org.alfresco.event.sdk.handling.handler;
 
 import org.alfresco.event.sdk.model.v1.model.EventType;
 
+import java.util.Set;
+
 /**
  * {@link EventHandler} for peer to peer association creation handling.
  */
 @FunctionalInterface
 public interface OnPeerAssocCreatedEventHandler extends PeerAssocEventHandler {
 
-    default EventType getHandledEventType() {
-        return EventType.PEER_ASSOC_CREATED;
+    default Set<EventType> getHandledEventTypes() {
+        return Set.of(EventType.PEER_ASSOC_CREATED);
     }
 }

--- a/alfresco-java-event-api/alfresco-java-event-api-handling/src/main/java/org/alfresco/event/sdk/handling/handler/OnPeerAssocDeletedEventHandler.java
+++ b/alfresco-java-event-api/alfresco-java-event-api-handling/src/main/java/org/alfresco/event/sdk/handling/handler/OnPeerAssocDeletedEventHandler.java
@@ -17,13 +17,15 @@ package org.alfresco.event.sdk.handling.handler;
 
 import org.alfresco.event.sdk.model.v1.model.EventType;
 
+import java.util.Set;
+
 /**
  * {@link EventHandler} for peer to peer association deletion handling.
  */
 @FunctionalInterface
 public interface OnPeerAssocDeletedEventHandler extends PeerAssocEventHandler {
 
-    default EventType getHandledEventType() {
-        return EventType.PEER_ASSOC_DELETED;
+    default Set<EventType> getHandledEventTypes() {
+        return Set.of(EventType.PEER_ASSOC_DELETED);
     }
 }

--- a/alfresco-java-event-api/alfresco-java-event-api-handling/src/main/java/org/alfresco/event/sdk/handling/handler/OnPermissionUpdatedEventHandler.java
+++ b/alfresco-java-event-api/alfresco-java-event-api-handling/src/main/java/org/alfresco/event/sdk/handling/handler/OnPermissionUpdatedEventHandler.java
@@ -17,13 +17,15 @@ package org.alfresco.event.sdk.handling.handler;
 
 import org.alfresco.event.sdk.model.v1.model.EventType;
 
+import java.util.Set;
+
 /**
  * {@link EventHandler} for permission update handling.
  */
 @FunctionalInterface
 public interface OnPermissionUpdatedEventHandler extends PermissionEventHandler {
 
-    default EventType getHandledEventType() {
-        return EventType.PERMISSION_UPDATED;
+    default Set<EventType> getHandledEventTypes() {
+        return Set.of(EventType.PERMISSION_UPDATED);
     }
 }

--- a/samples/event-api-handlers/src/main/java/org/alfresco/sdk/sample/event/handler/MultipleEventTypeHandler.java
+++ b/samples/event-api-handlers/src/main/java/org/alfresco/sdk/sample/event/handler/MultipleEventTypeHandler.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021-2021 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.alfresco.sdk.sample.event.handler;
+
+import org.alfresco.event.sdk.handling.handler.OnNodeCreatedEventHandler;
+import org.alfresco.event.sdk.handling.handler.OnNodeUpdatedEventHandler;
+import org.alfresco.event.sdk.model.v1.model.DataAttributes;
+import org.alfresco.event.sdk.model.v1.model.EventType;
+import org.alfresco.event.sdk.model.v1.model.NodeResource;
+import org.alfresco.event.sdk.model.v1.model.RepoEvent;
+import org.alfresco.event.sdk.model.v1.model.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+
+/**
+ * Sample event handler to demonstrate reacting to more than one event type. You only need to provide your own implementation of the method
+ * <code>getHandledEventTypes</code>.
+ */
+@Component
+public class MultipleEventTypeHandler implements OnNodeCreatedEventHandler, OnNodeUpdatedEventHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MultipleEventTypeHandler.class);
+
+    @Override
+    public void handleEvent(final RepoEvent<DataAttributes<Resource>> event) {
+        LOGGER.info("Multiple event handler detecting an event of type {}", event.getType());
+    }
+
+    @Override public Set<EventType> getHandledEventTypes() {
+        return Set.of(EventType.NODE_CREATED, EventType.NODE_UPDATED);
+    }
+}


### PR DESCRIPTION
Modify the method `getEventType` of the interface `EventHandler` to return
a set of event types.

This way, an integrator can create a handler class that implements more
than one of the interfaces provided in the hierarchy simply by providing
an implementation of the method `getEventTypes`.

The documentation has been updated to reflect this possibility and a sample
implementation of multiple event types handler has been provided in the
event handlers sample application.