### PR TITLE
REPO-5646 Update spring cloud version

### DIFF
--- a/alfresco-java-rest-api/pom.xml
+++ b/alfresco-java-rest-api/pom.xml
@@ -21,7 +21,7 @@
   </modules>
 
   <properties>
-    <spring-cloud.version>2020.0.1</spring-cloud.version>
+    <spring-cloud.version>2020.0.3</spring-cloud.version>
     <swagger-core.version>1.5.20</swagger-core.version>
   </properties>
 


### PR DESCRIPTION
Update the spring cloud version to 2020.0.3 that is compatible with
Spring Boot 2.4.x (version used in java SDK) and 2.5.x (version used
in alfresco event gateway).