### PR TITLE
REPO-5613 SDK - REST API - Support OAuth in addition to basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,30 +5,45 @@
 </p>
 
 ## What is Alfresco Java SDK?
-The Alfresco Java SDK includes a set of APIs and samples that allows developers to quickly build out-of-process Java applications that integrate with Alfresco. <br/>
 
-This SDK provides functionality to connect to both on-premise and Cloud-based servers. Alfresco servers of version 7.x and above are supported. 
+The Alfresco Java SDK includes a set of APIs and samples that allows developers to quickly build
+out-of-process Java applications that integrate with Alfresco. <br/>
+
+This SDK provides functionality to connect to both on-premise and Cloud-based servers. Alfresco
+servers of version 7.x and above are supported.
 
 ## What is Out-of-Process?
 
-[Alfresco SDK 4.x](https://github.com/Alfresco/alfresco-sdk) was conceived for creating JAR and AMP modules that run in the same JVM as Alfresco Repository or Share. This is still the default extension approach for certain use cases (e.g. Content modelling).
-                                                             
-Alfresco Java SDK 5.0.0 is not a continuation of 4.x. Instead, it is an additional SDK that allows developers to create out-of-process extensions. These applications run separately, consuming public APIs exposed by Alfresco Repository.
+[Alfresco SDK 4.x](https://github.com/Alfresco/alfresco-sdk) was conceived for creating JAR and AMP
+modules that run in the same JVM as Alfresco Repository or Share. This is still the default
+extension approach for certain use cases (e.g. Content modelling).
+
+Alfresco Java SDK 5.0.0 is not a continuation of 4.x. Instead, it is an additional SDK that allows
+developers to create out-of-process extensions. These applications run separately, consuming public
+APIs exposed by Alfresco Repository.
 
 <p align="center">
   <img title="alfresco" alt='alfresco' src='docs/images/simple_integration_diagram.png'></img>
 </p>
 
-Existing projects with business logic that could be lifted out and implemented as an external service can use Alfresco Java SDK 5.0 and start using the public REST API to interact with the Repository. Any business logic executed as a result of an action in the Repository, such as document or folder uploaded, updated, deleted, can be reimplemented as an external out-process extension utilizing the new Event API.
+Existing projects with business logic that could be lifted out and implemented as an external
+service can use Alfresco Java SDK 5.0 and start using the public REST API to interact with the
+Repository. Any business logic executed as a result of an action in the Repository, such as document
+or folder uploaded, updated, deleted, can be reimplemented as an external out-process extension
+utilizing the new Event API.
 
 ## How does it work?
 
 Alfresco Java SDK consist of the following groups of libraries:
-* [alfresco-java-rest-api](alfresco-java-rest-api): Allows applications to consume Alfresco public REST APIs.
-* [alfresco-java-event-api](alfresco-java-event-api): Allows applications to react to events produced by Alfresco Repository.
 
-The [samples](samples) folder includes examples, sample applications and code snippets of the different features supported by the SDK. Each sample application contains a `docker-compose` file and scripts that allows you to build and run the extension.  
+* [alfresco-java-rest-api](alfresco-java-rest-api): Allows applications to consume Alfresco public
+  REST APIs.
+* [alfresco-java-event-api](alfresco-java-event-api): Allows applications to react to events
+  produced by Alfresco Repository.
 
+The [samples](samples) folder includes examples, sample applications and code snippets of the
+different features supported by the SDK. Each sample application contains a `docker-compose` file
+and scripts that allows you to build and run the extension.
 
 ### Pre-Requisites
 
@@ -44,72 +59,87 @@ The [samples](samples) folder includes examples, sample applications and code sn
 Maven:
 
 First, add to the repositories the Alfresco public repository containing the artifacts:
+
 ```xml
-  <repositories>
-  
-    <repository>
-      <id>alfresco-public</id>
-      <url>https://artifacts.alfresco.com/nexus/content/groups/public</url>
-    </repository>
-  
-  </repositories>
+
+<repositories>
+
+  <repository>
+    <id>alfresco-public</id>
+    <url>https://artifacts.alfresco.com/nexus/content/groups/public</url>
+  </repository>
+
+</repositories>
 ```
+
 Then, add the dependency on the desired starter(s)
+
 ```xml
-  <dependencies>
 
-    <!-- Java REST API -->
-    <dependency>
-      <groupId>org.alfresco</groupId>
-      <artifactId>alfresco-java-rest-api-spring-boot-starter</artifactId>
-      <version>5.0.0</version>
-    </dependency>
+<dependencies>
 
-    <!-- Java Event API -->
-    <dependency>
-      <groupId>org.alfresco</groupId>
-      <artifactId>alfresco-java-event-api-spring-boot-starter</artifactId>
-      <version>5.0.0</version>
-    </dependency>
-  </dependencies>
+  <!-- Java REST API -->
+  <dependency>
+    <groupId>org.alfresco</groupId>
+    <artifactId>alfresco-java-rest-api-spring-boot-starter</artifactId>
+    <version>5.0.0</version>
+  </dependency>
+
+  <!-- Java Event API -->
+  <dependency>
+    <groupId>org.alfresco</groupId>
+    <artifactId>alfresco-java-event-api-spring-boot-starter</artifactId>
+    <version>5.0.0</version>
+  </dependency>
+</dependencies>
 ```
 
 Gradle:
 
 First, add to the repositories the Alfresco public repository containing the artifacts:
+
 ```groovy
 repositories {
-    maven {
-        url "https://artifacts.alfresco.com/nexus/content/groups/public"
-    }
+  maven {
+    url "https://artifacts.alfresco.com/nexus/content/groups/public"
+  }
 }
 ```
+
 Then, add the dependency on the desired starter(s)
+
 ```groovy
 compile "org.alfresco:alfresco-java-rest-api-spring-boot-starter:5.0.0"
 compile "org.alfresco:alfresco-java-event-api-spring-boot-starter:5.0.0"
 ```
 
+#### 3. Configure Event API
 
-#### 3. Configure Event API 
+In your ```application.properties``` file define the properties required to connect to the ActiveMQ
+broker in order to handle Repository events:
 
-In your ```application.properties``` file define the properties required to connect to the ActiveMQ broker in order to handle Repository events:
 ```
 spring.activemq.brokerUrl=tcp://activemq-host:61616
 ```
+
 Alternatively, set `SPRING_ACTIVEMQ_BROKER_URL` environment variable.
 
-Also, this property is required if you want Spring Boot to auto-define the ActiveMQConnectionFactory, otherwise you can define that bean in Spring config
+Also, this property is required if you want Spring Boot to auto-define the
+ActiveMQConnectionFactory, otherwise you can define that bean in Spring config
+
 ```
 spring.jms.cache.enabled=false
 ```
+
 Similarly, you can alternatively set `SPRING_JMS_CACHE_ENABLED` environment variable.
 
-For additional configuration properties of Event API, check [alfresco-java-event-api](alfresco-java-event-api).
+For additional configuration properties of Event API,
+check [alfresco-java-event-api](alfresco-java-event-api).
 
-#### 4. Configure REST API 
+#### 4. Configure REST API
 
-In your ```application.properties``` file provide URL, authentication mechanism and credentials for accessing the REST API:
+In your ```application.properties``` file provide URL, authentication mechanism and credentials for
+accessing the REST API:
 
 ```
 content.service.url=http://repository:8080
@@ -117,18 +147,41 @@ content.service.security.basicAuth.username=admin
 content.service.security.basicAuth.password=admin
 ```
 
-Alternatively, if you are using OAuth2, you can use client-credential based authentication:
+If you are using OAuth2, you can use client-credential based authentication:
 
 ```
-security.oauth2.client.grantType=client_credentials
-security.oauth2.client.clientId=clientId
-security.oauth2.client.clientSecret=clientSecret
-security.oauth2.client.accessTokenUri=${keycloak.auth-server-url}/realms/${keycloak.realm}/protocol/openid-connect/token
+spring.security.oauth2.client.registration.alfresco-rest-api.provider=alfresco-identity-service
+spring.security.oauth2.client.registration.alfresco-rest-api.client-id=clientId
+spring.security.oauth2.client.registration.alfresco-rest-api.client-secret=clientSecret
+spring.security.oauth2.client.registration.alfresco-rest-api.authorization-grant-type=client_credentials
+spring.security.oauth2.client.provider.alfresco-identity-service.token-uri=${keycloak.auth-server-url}/auth/realms/${keycloak.realm}/protocol/openid-connect/token
 ```
+
+Or OAuth2 password based authentication:
+
+```
+spring.security.oauth2.client.registration.alfresco-rest-api.provider=alfresco-identity-service
+spring.security.oauth2.client.registration.alfresco-rest-api.client-id=clientId
+spring.security.oauth2.client.registration.alfresco-rest-api.client-secret=clientSecret
+spring.security.oauth2.client.registration.alfresco-rest-api.username=username
+spring.security.oauth2.client.registration.alfresco-rest-api.password=pwd
+spring.security.oauth2.client.registration.alfresco-rest-api.authorization-grant-type=password
+spring.security.oauth2.client.provider.alfresco-identity-service.token-uri=${keycloak.auth-server-url}/auth/realms/${keycloak.realm}/protocol/openid-connect/token
+```
+
+Finally, if you want to provide a custom authentication mechanism, you can enable the delegated
+external authentication:
+
+```
+content.service.security.delegated=true
+```
+
+And provide a bean that implements the interface ```DelegatedAuthenticationProvider```.
 
 #### 5. Handle events produced by the Repository
 
-Use out-of-the-box Event Handlers to handle specific events, using Event Filters to react to the event, only if it meets certain conditions.
+Use out-of-the-box Event Handlers to handle specific events, using Event Filters to react to the
+event, only if it meets certain conditions.
 
 ```java
 /**
@@ -137,17 +190,18 @@ Use out-of-the-box Event Handlers to handle specific events, using Event Filters
 @Component
 public class ContentUpdatedHandler implements OnNodeUpdatedEventHandler {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ContentUpdatedHandler.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(ContentUpdatedHandler.class);
 
-    @Override
-    public void handleEvent(final RepoEvent<DataAttributes<Resource>> repoEvent) {
-        LOGGER.info("The content of the node {} has been updated!", ((NodeResource) repoEvent.getData().getResource()).getName());
-    }
+  @Override
+  public void handleEvent(final RepoEvent<DataAttributes<Resource>> repoEvent) {
+    LOGGER.info("The content of the node {} has been updated!",
+      ((NodeResource) repoEvent.getData().getResource()).getName());
+  }
 
-    @Override
-    public EventFilter getEventFilter() {
-        return ContentChangedFilter.get();
-    }
+  @Override
+  public EventFilter getEventFilter() {
+    return ContentChangedFilter.get();
+  }
 }
 ```
 
@@ -155,49 +209,51 @@ Use `@Order` annotation to define an execution order of multiple event handlers.
 
 ```java
     /**
-     * This event handler definition illustrates how you can use Spring's {@link Order} annotation to sort the execution of event handlers.
-     */
-    @Bean
-    @Order(10)
-    public OnNodeCreatedEventHandler firstCustomNodeCreatedEventHandler() {
-        return repoEvent -> LOGGER.info("First Event handler triggered on node created - Event: {}", repoEvent);
-    }
+ * This event handler definition illustrates how you can use Spring's {@link Order} annotation to sort the execution of event handlers.
+ */
+@Bean
+@Order(10)
+public OnNodeCreatedEventHandler firstCustomNodeCreatedEventHandler(){
+  return repoEvent->LOGGER.info("First Event handler triggered on node created - Event: {}",repoEvent);
+  }
 
-    /**
-     * This event handler definition illustrates how you can use Spring's {@link Order} annotation to sort the execution of event handlers.
-     */
-    @Bean
-    @Order(20)
-    public OnNodeCreatedEventHandler secondCustomNodeCreatedEventHandler() {
-        return repoEvent -> LOGGER.info("Second Event handler triggered on node created - Event: {}", repoEvent);
-    }
+/**
+ * This event handler definition illustrates how you can use Spring's {@link Order} annotation to sort the execution of event handlers.
+ */
+@Bean
+@Order(20)
+public OnNodeCreatedEventHandler secondCustomNodeCreatedEventHandler(){
+  return repoEvent->LOGGER.info("Second Event handler triggered on node created - Event: {}",repoEvent);
+  }
 ```
 
 Alternatively, use Spring Integration to consume events:
 
 ```java
     @Bean
-    public IntegrationFlow logTheCreationOfHTMLContent() {
-        return IntegrationFlows.from(EventChannels.MAIN)
-                .filter(IntegrationEventFilter.of(EventTypeFilter.NODE_CREATED
-                                                    .and(MimeTypeFilter.of("text/html"))))
-                .handle(t -> LOGGER.info("An HTML content has been created! - Event: {}", t.getPayload().toString()))
-                .get();
-    }
+public IntegrationFlow logTheCreationOfHTMLContent(){
+  return IntegrationFlows.from(EventChannels.MAIN)
+  .filter(IntegrationEventFilter.of(EventTypeFilter.NODE_CREATED
+  .and(MimeTypeFilter.of("text/html"))))
+  .handle(t->LOGGER.info("An HTML content has been created! - Event: {}",t.getPayload().toString()))
+  .get();
+  }
 ```
 
-You can find more information about how to consume events at [alfresco-java-event-api](alfresco-java-event-api).
+You can find more information about how to consume events
+at [alfresco-java-event-api](alfresco-java-event-api).
 
 #### 6. Consume the REST API
 
 ```java
     CommentsApi commentsApi;
 
-    public void addComentToNode(final String nodeId) {
-        CommentBody commentBody = new CommentBody().content("I like this file");
-        commentsApi.createComment(nodeId, commentBody);
-    }
-}
+public void addComentToNode(final String nodeId){
+  CommentBody commentBody=new CommentBody().content("I like this file");
+  commentsApi.createComment(nodeId,commentBody);
+  }
+  }
 ```
 
-You can find more information about how to consume the REST API at [alfresco-java-rest-api](alfresco-java-rest-api).
+You can find more information about how to consume the REST API
+at [alfresco-java-rest-api](alfresco-java-rest-api).

--- a/alfresco-java-rest-api/alfresco-java-rest-api-common/pom.xml
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-common/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.alfresco</groupId>
+    <artifactId>alfresco-java-rest-api</artifactId>
+    <version>5.0.4-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>alfresco-java-rest-api-common</artifactId>
+  <name>Alfresco Java REST API :: Common functionality</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-starter-openfeign</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-oauth2-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/alfresco-java-rest-api/alfresco-java-rest-api-common/src/main/java/org/alfresco/rest/sdk/feign/DelegatedAuthenticationProvider.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-common/src/main/java/org/alfresco/rest/sdk/feign/DelegatedAuthenticationProvider.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021-2021 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.alfresco.rest.sdk.feign;
+
+import feign.RequestTemplate;
+
+/**
+ * Interface to be implemented to allow a delegated authentication in the SDK feign clients.
+ */
+@FunctionalInterface
+public interface DelegatedAuthenticationProvider {
+
+    /**
+     * Set the authentication details in the request template.
+     *
+     * @param template {@link RequestTemplate} to set the authentication details
+     */
+    void setAuthentication(RequestTemplate template);
+}

--- a/alfresco-java-rest-api/alfresco-java-rest-api-common/src/main/java/org/alfresco/rest/sdk/feign/DelegatedAuthenticationRequestInterceptor.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-common/src/main/java/org/alfresco/rest/sdk/feign/DelegatedAuthenticationRequestInterceptor.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021-2021 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.alfresco.rest.sdk.feign;
+
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Feign {@link RequestInterceptor} that delegates the authentication in an external class implementing {@link DelegatedAuthenticationProvider}.
+ */
+public class DelegatedAuthenticationRequestInterceptor implements RequestInterceptor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DelegatedAuthenticationRequestInterceptor.class);
+
+    private final DelegatedAuthenticationProvider delegatedAuthenticationProvider;
+
+    /**
+     * Constructor.
+     *
+     * @param delegatedAuthenticationProvider given {@link DelegatedAuthenticationProvider}
+     */
+    public DelegatedAuthenticationRequestInterceptor(final DelegatedAuthenticationProvider delegatedAuthenticationProvider) {
+        this.delegatedAuthenticationProvider = Objects.requireNonNull(delegatedAuthenticationProvider);
+    }
+
+    @Override
+    public void apply(RequestTemplate requestTemplate) {
+        LOGGER.debug("Delegating authentication setup to the provider {}", delegatedAuthenticationProvider);
+        delegatedAuthenticationProvider.setAuthentication(requestTemplate);
+    }
+}

--- a/alfresco-java-rest-api/alfresco-java-rest-api-common/src/main/java/org/alfresco/rest/sdk/feign/config/BasicAuthConfiguration.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-common/src/main/java/org/alfresco/rest/sdk/feign/config/BasicAuthConfiguration.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021-2021 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.alfresco.rest.sdk.feign.config;
+
+import feign.auth.BasicAuthRequestInterceptor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration for basic authentication. It configures a {@link BasicAuthRequestInterceptor} that uses the credentials configured in the properties
+ * <code>content.service.security.basicAuth.username</code> and <code>content.service.security.basicAuth.password</code>.
+ */
+@Configuration
+@ConditionalOnProperty("content.service.security.basicAuth.username")
+public class BasicAuthConfiguration {
+
+    @Value("${content.service.security.basicAuth.username:#{null}}")
+    private String basicAuthUsername;
+    @Value("${content.service.security.basicAuth.password:#{null}}")
+    private String basicAuthPassword;
+
+    @Bean
+    @ConditionalOnProperty("content.service.security.basicAuth.username")
+    public BasicAuthRequestInterceptor basicAuthRequestInterceptor() {
+        return new BasicAuthRequestInterceptor(this.basicAuthUsername, this.basicAuthPassword);
+    }
+}

--- a/alfresco-java-rest-api/alfresco-java-rest-api-common/src/main/java/org/alfresco/rest/sdk/feign/config/DelegatedAuthenticationConfiguration.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-common/src/main/java/org/alfresco/rest/sdk/feign/config/DelegatedAuthenticationConfiguration.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021-2021 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.alfresco.rest.sdk.feign.config;
+
+import org.alfresco.rest.sdk.feign.DelegatedAuthenticationProvider;
+import org.alfresco.rest.sdk.feign.DelegatedAuthenticationRequestInterceptor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration for external delegated authentication mechanism. This must be provided by the integrator of the SDK in the form of a bean that implements the
+ * interface {@link DelegatedAuthenticationRequestInterceptor}. This authentication method is enabled via the property
+ * <code>content.service.security.delegated</code>.
+ */
+@Configuration
+@ConditionalOnProperty("content.service.security.delegated")
+public class DelegatedAuthenticationConfiguration {
+
+    @Bean
+    public DelegatedAuthenticationRequestInterceptor delegatedAuthenticationRequestInterceptor(DelegatedAuthenticationProvider
+        delegatedAuthenticationProvider) {
+        return new DelegatedAuthenticationRequestInterceptor(delegatedAuthenticationProvider);
+    }
+}

--- a/alfresco-java-rest-api/alfresco-java-rest-api-common/src/main/java/org/alfresco/rest/sdk/feign/config/OAuth2Configuration.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-common/src/main/java/org/alfresco/rest/sdk/feign/config/OAuth2Configuration.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2021-2021 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.alfresco.rest.sdk.feign.config;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.alfresco.rest.sdk.feign.oauth2.OAuth2FeignRequestInterceptor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientPropertiesRegistrationAdapter;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.OAuth2AuthorizationContext;
+import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProvider;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+
+/**
+ * Configuration for OAuth2 authentication flows. It configures a {@link OAuth2FeignRequestInterceptor} that retrieves the access token and generates the
+ * authorization header with the bearer. This is based in the OAuth2 support provided by the Spring Security module. So, the configuration must be done using
+ * the corresponding properties. The configuration of the client must be done using the properties
+ * <code>spring.security.oauth2.client.registration.alfresco-rest-api.xxxx</code>.
+ */
+@Configuration
+@EnableConfigurationProperties({OAuth2ClientProperties.class})
+@ConditionalOnProperty("spring.security.oauth2.client.registration.alfresco-rest-api.provider")
+public class OAuth2Configuration {
+
+    private static final String OAUTH2_CLIENT_REGISTRATION_ID = "alfresco-rest-api";
+
+    @Value("${spring.security.oauth2.client.registration.alfresco-rest-api.username:#{null}}")
+    private String oAuth2Username;
+    @Value("${spring.security.oauth2.client.registration.alfresco-rest-api.password:#{null}}")
+    private String oAuth2Password;
+
+    @Bean
+    @ConditionalOnMissingBean({ClientRegistrationRepository.class})
+    public InMemoryClientRegistrationRepository clientRegistrationRepository(OAuth2ClientProperties properties) {
+        List<ClientRegistration> registrations = new ArrayList(OAuth2ClientPropertiesRegistrationAdapter.getClientRegistrations(properties).values());
+        return new InMemoryClientRegistrationRepository(registrations);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean({OAuth2AuthorizedClientService.class})
+    public InMemoryOAuth2AuthorizedClientService authorizedClientService(ClientRegistrationRepository clientRegistrationRepository) {
+        return new InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public OAuth2AuthorizedClientProvider oAuth2AuthorizedClientProvider() {
+        return OAuth2AuthorizedClientProviderBuilder.builder()
+            .clientCredentials()
+            .password()
+            .build();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public OAuth2AuthorizedClientManager authorizedClientManager(final ClientRegistrationRepository clientRegistrationRepository,
+        final OAuth2AuthorizedClientService authorizedClientService, OAuth2AuthorizedClientProvider oAuth2AuthorizedClientProvider) {
+        AuthorizedClientServiceOAuth2AuthorizedClientManager authorizedClientServiceOAuth2AuthorizedClientManager =
+            new AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientService);
+        authorizedClientServiceOAuth2AuthorizedClientManager.setAuthorizedClientProvider(oAuth2AuthorizedClientProvider);
+        authorizedClientServiceOAuth2AuthorizedClientManager.setContextAttributesMapper(OAuth2AuthorizeRequest::getAttributes);
+        return authorizedClientServiceOAuth2AuthorizedClientManager;
+    }
+
+    @Bean
+    public OAuth2AuthorizeRequest oAuth2AuthorizeRequest() {
+        return OAuth2AuthorizeRequest.withClientRegistrationId(OAUTH2_CLIENT_REGISTRATION_ID)
+            .principal(new AnonymousAuthenticationToken("feignClient", "feignClient",
+                AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")))
+            .attribute(OAuth2AuthorizationContext.USERNAME_ATTRIBUTE_NAME, oAuth2Username)
+            .attribute(OAuth2AuthorizationContext.PASSWORD_ATTRIBUTE_NAME, oAuth2Password)
+            .build();
+    }
+
+    @Bean
+    public OAuth2FeignRequestInterceptor requestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager,
+        OAuth2AuthorizeRequest oAuth2AuthorizeRequest) {
+        return new OAuth2FeignRequestInterceptor(oAuth2AuthorizedClientManager, oAuth2AuthorizeRequest);
+    }
+}

--- a/alfresco-java-rest-api/alfresco-java-rest-api-common/src/main/java/org/alfresco/rest/sdk/feign/oauth2/OAuth2FeignRequestInterceptor.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-common/src/main/java/org/alfresco/rest/sdk/feign/oauth2/OAuth2FeignRequestInterceptor.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021-2021 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.alfresco.rest.sdk.feign.oauth2;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+
+/**
+ * Feign {@link RequestInterceptor} that makes use of the OAuth2 support classes from Spring Security to obtain an access token and add the corresponding
+ * authorization header to the feign request.
+ */
+public class OAuth2FeignRequestInterceptor implements RequestInterceptor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OAuth2FeignRequestInterceptor.class);
+    private static final String AUTH_HEADER_FORMAT = "%s %s";
+
+    private final OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager;
+    private final OAuth2AuthorizeRequest oAuth2AuthorizeRequest;
+
+    /**
+     * Constructor.
+     *
+     * @param oAuth2AuthorizedClientManager given {@link OAuth2AuthorizedClientManager}
+     * @param oAuth2AuthorizeRequest        given {@link OAuth2AuthorizeRequest}
+     */
+    public OAuth2FeignRequestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager, OAuth2AuthorizeRequest oAuth2AuthorizeRequest) {
+        this.oAuth2AuthorizedClientManager = oAuth2AuthorizedClientManager;
+        this.oAuth2AuthorizeRequest = oAuth2AuthorizeRequest;
+    }
+
+    @Override
+    public void apply(RequestTemplate template) {
+        LOGGER.debug("Applying OAuth2 authentication to feign request template {}", template);
+        template.header(AUTHORIZATION, getAuthorizationToken());
+    }
+
+    private String getAuthorizationToken() {
+        final OAuth2AccessToken accessToken = oAuth2AuthorizedClientManager.authorize(oAuth2AuthorizeRequest).getAccessToken();
+        return String.format(AUTH_HEADER_FORMAT, accessToken.getTokenType().getValue(), accessToken.getTokenValue());
+    }
+}

--- a/alfresco-java-rest-api/alfresco-java-rest-api-common/src/test/java/org/alfresco/rest/sdk/feign/DelegatedAuthenticationRequestInterceptorTest.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-common/src/test/java/org/alfresco/rest/sdk/feign/DelegatedAuthenticationRequestInterceptorTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021-2021 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.alfresco.rest.sdk.feign;
+
+import static org.mockito.Mockito.verify;
+
+import feign.RequestTemplate;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * Unit tests for {@link DelegatedAuthenticationRequestInterceptor}.
+ */
+public class DelegatedAuthenticationRequestInterceptorTest {
+
+    @Mock
+    private DelegatedAuthenticationProvider mockDelegatedAuthenticationProvider;
+
+    private DelegatedAuthenticationRequestInterceptor delegatedAuthenticationRequestInterceptor;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        delegatedAuthenticationRequestInterceptor = new DelegatedAuthenticationRequestInterceptor(mockDelegatedAuthenticationProvider);
+    }
+
+    @Test
+    public void should_invokeDelegatedAuthenticationProvider_when_interceptorIsApplied() {
+        RequestTemplate requestTemplate = new RequestTemplate();
+
+        delegatedAuthenticationRequestInterceptor.apply(requestTemplate);
+
+        verify(mockDelegatedAuthenticationProvider).setAuthentication(requestTemplate);
+    }
+}

--- a/alfresco-java-rest-api/alfresco-java-rest-api-common/src/test/java/org/alfresco/rest/sdk/feign/oauth2/OAuth2FeignRequestInterceptorTest.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-common/src/test/java/org/alfresco/rest/sdk/feign/oauth2/OAuth2FeignRequestInterceptorTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021-2021 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.alfresco.rest.sdk.feign.oauth2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+import feign.RequestTemplate;
+import java.util.Collection;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2AccessToken.TokenType;
+
+/**
+ * Unit tests for {@link OAuth2FeignRequestInterceptor}.
+ */
+public class OAuth2FeignRequestInterceptorTest {
+
+    private static final String TEST_TOKEN_VALUE = "test";
+
+    @Mock
+    private OAuth2AuthorizedClientManager mockOAuth2AuthorizedClientManager;
+    @Mock
+    private OAuth2AuthorizedClient mockOAuth2AuthorizedClient;
+
+    private OAuth2AuthorizeRequest oAuth2AuthorizeRequest;
+
+    private OAuth2FeignRequestInterceptor oAuth2FeignRequestInterceptor;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        oAuth2AuthorizeRequest = OAuth2AuthorizeRequest.withClientRegistrationId("test")
+            .principal(new AnonymousAuthenticationToken("feignClient", "feignClient", AuthorityUtils
+                .createAuthorityList(new String[]{"ROLE_ANONYMOUS"}))).build();
+        oAuth2FeignRequestInterceptor = new OAuth2FeignRequestInterceptor(mockOAuth2AuthorizedClientManager, oAuth2AuthorizeRequest);
+    }
+
+    @Test
+    public void should_addOAuthAuthorizationHeader_when_interceptorIsApplied() {
+        given(mockOAuth2AuthorizedClientManager.authorize(oAuth2AuthorizeRequest)).willReturn(mockOAuth2AuthorizedClient);
+        OAuth2AccessToken oAuth2AccessToken = new OAuth2AccessToken(TokenType.BEARER, TEST_TOKEN_VALUE, null, null);
+        given(mockOAuth2AuthorizedClient.getAccessToken()).willReturn(oAuth2AccessToken);
+        RequestTemplate requestTemplate = new RequestTemplate();
+
+        oAuth2FeignRequestInterceptor.apply(requestTemplate);
+
+        Collection<String> authCollection = requestTemplate.headers().get(AUTHORIZATION);
+        assertThat(authCollection).hasSize(1);
+        assertThat(authCollection).containsOnly("Bearer test");
+    }
+}

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/alfresco-event-gateway-api/pom.xml
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/alfresco-event-gateway-api/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.alfresco</groupId>
@@ -23,14 +24,18 @@
       <artifactId>spring-boot-starter-oauth2-client</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.alfresco</groupId>
+      <artifactId>alfresco-java-rest-api-common</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
     </dependency>
-      <dependency>
-        <groupId>javax.validation</groupId>
-        <artifactId>validation-api</artifactId>
-        <scope>provided</scope>
-      </dependency>
+    <dependency>
+      <groupId>javax.validation</groupId>
+      <artifactId>validation-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/alfresco-event-gateway-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/alfresco-event-gateway-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
@@ -15,17 +15,104 @@
  */
 package io.swagger.configuration;
 
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
+import feign.auth.BasicAuthRequestInterceptor;
+import java.util.ArrayList;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientPropertiesRegistrationAdapter;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
 
 @Configuration
-@EnableConfigurationProperties
+@EnableConfigurationProperties({OAuth2ClientProperties.class})
 public class ClientConfiguration {
 
+    @Configuration
+    @ConditionalOnProperty("content.service.security.basicAuth.username")
+    protected static class BasicAuthConfiguration {
+
+        @Value("${content.service.security.basicAuth.username:#{null}}")
+        private String basicAuthUsername;
+        @Value("${content.service.security.basicAuth.password:#{null}}")
+        private String basicAuthPassword;
+
+        @Bean
+        @ConditionalOnProperty("content.service.security.basicAuth.username")
+        public BasicAuthRequestInterceptor basicAuthRequestInterceptor() {
+            return new BasicAuthRequestInterceptor(this.basicAuthUsername, this.basicAuthPassword);
+        }
+    }
+
+    @Configuration
+    @ConditionalOnProperty("spring.security.oauth2.client.registration.alfresco-rest-api.provider")
+    protected static class OAuth2Configuration {
+
+        @Bean
+        @ConditionalOnMissingBean({ClientRegistrationRepository.class})
+        public InMemoryClientRegistrationRepository clientRegistrationRepository(OAuth2ClientProperties properties) {
+            List<ClientRegistration> registrations = new ArrayList(OAuth2ClientPropertiesRegistrationAdapter.getClientRegistrations(properties).values());
+            return new InMemoryClientRegistrationRepository(registrations);
+        }
+
+        @Bean
+        @ConditionalOnMissingBean({OAuth2AuthorizedClientService.class})
+        public InMemoryOAuth2AuthorizedClientService authorizedClientService(ClientRegistrationRepository clientRegistrationRepository) {
+            return new InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository);
+        }
+
+        @Bean
+        @ConditionalOnMissingBean
+        public OAuth2AuthorizedClientManager authorizedClientManager(final ClientRegistrationRepository clientRegistrationRepository,
+            final OAuth2AuthorizedClientService authorizedClientService) {
+            return new AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientService);
+        }
+
+        @Bean
+        public OAuth2FeignRequestInterceptor requestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager) {
+            return new OAuth2FeignRequestInterceptor(oAuth2AuthorizedClientManager,
+                OAuth2AuthorizeRequest.withClientRegistrationId("alfresco-rest-api")
+                    .principal(new AnonymousAuthenticationToken("feignClient", "feignClient", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")))
+                    .build());
+        }
+
+        public class OAuth2FeignRequestInterceptor implements RequestInterceptor {
+
+            private final OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager;
+            private final OAuth2AuthorizeRequest oAuth2AuthorizeRequest;
+
+            public OAuth2FeignRequestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager, OAuth2AuthorizeRequest oAuth2AuthorizeRequest) {
+                this.oAuth2AuthorizedClientManager = oAuth2AuthorizedClientManager;
+                this.oAuth2AuthorizeRequest = oAuth2AuthorizeRequest;
+            }
+
+            @Override
+            public void apply(RequestTemplate template) {
+                template.header(AUTHORIZATION, getAuthorizationToken());
+            }
+
+            private String getAuthorizationToken() {
+                final OAuth2AccessToken accessToken = oAuth2AuthorizedClientManager.authorize(oAuth2AuthorizeRequest).getAccessToken();
+                return String.format("%s %s", accessToken.getTokenType().getValue(), accessToken.getTokenValue());
+            }
+        }
+    }
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/alfresco-event-gateway-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/alfresco-event-gateway-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
@@ -15,33 +15,11 @@
  */
 package io.swagger.configuration;
 
-import feign.auth.BasicAuthRequestInterceptor;
-import java.util.ArrayList;
-import java.util.List;
-import org.alfresco.rest.sdk.feign.DelegatedAuthenticationProvider;
-import org.alfresco.rest.sdk.feign.DelegatedAuthenticationRequestInterceptor;
-import org.alfresco.rest.sdk.feign.oauth2.OAuth2FeignRequestInterceptor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
-import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientPropertiesRegistrationAdapter;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
+import org.alfresco.rest.sdk.feign.config.BasicAuthConfiguration;
+import org.alfresco.rest.sdk.feign.config.DelegatedAuthenticationConfiguration;
+import org.alfresco.rest.sdk.feign.config.OAuth2Configuration;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.authentication.AnonymousAuthenticationToken;
-import org.springframework.security.core.authority.AuthorityUtils;
-import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
-import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService;
-import org.springframework.security.oauth2.client.OAuth2AuthorizationContext;
-import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProvider;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
-import org.springframework.security.oauth2.client.registration.ClientRegistration;
-import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
-import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.context.annotation.Import;
 
 /**
  * Feign client Spring configuration that provides support for different authentication methods. Currently, supported methods are:
@@ -53,109 +31,7 @@ import org.springframework.security.oauth2.client.registration.InMemoryClientReg
  * </ul>
  */
 @Configuration
-@EnableConfigurationProperties({OAuth2ClientProperties.class})
+@Import({BasicAuthConfiguration.class, OAuth2Configuration.class, DelegatedAuthenticationConfiguration.class})
 public class ClientConfiguration {
 
-    /**
-     * Configuration for basic authentication. It configures a {@link BasicAuthRequestInterceptor} that uses the credentials configured in the properties
-     * <code>content.service.security.basicAuth.username</code> and <code>content.service.security.basicAuth.password</code>.
-     */
-    @Configuration
-    @ConditionalOnProperty("content.service.security.basicAuth.username")
-    protected static class BasicAuthConfiguration {
-
-        @Value("${content.service.security.basicAuth.username:#{null}}")
-        private String basicAuthUsername;
-        @Value("${content.service.security.basicAuth.password:#{null}}")
-        private String basicAuthPassword;
-
-        @Bean
-        @ConditionalOnProperty("content.service.security.basicAuth.username")
-        public BasicAuthRequestInterceptor basicAuthRequestInterceptor() {
-            return new BasicAuthRequestInterceptor(this.basicAuthUsername, this.basicAuthPassword);
-        }
-    }
-
-    /**
-     * Configuration for OAuth2 authentication flows. It configures a {@link OAuth2FeignRequestInterceptor} that retrieves the access token and generates the
-     * authorization header with the bearer. This is based in the OAuth2 support provided by the Spring Security module. So, the configuration must be done
-     * using the corresponding properties. The configuration of the client must be done using the properties
-     * <code>spring.security.oauth2.client.registration.alfresco-rest-api.xxxx</code>.
-     */
-    @Configuration
-    @ConditionalOnProperty("spring.security.oauth2.client.registration.alfresco-rest-api.provider")
-    protected static class OAuth2Configuration {
-
-        private static final String OAUTH2_CLIENT_REGISTRATION_ID = "alfresco-rest-api";
-
-        @Value("${spring.security.oauth2.client.registration.alfresco-rest-api.username:#{null}}")
-        private String oAuth2Username;
-        @Value("${spring.security.oauth2.client.registration.alfresco-rest-api.password:#{null}}")
-        private String oAuth2Password;
-
-        @Bean
-        @ConditionalOnMissingBean({ClientRegistrationRepository.class})
-        public InMemoryClientRegistrationRepository clientRegistrationRepository(OAuth2ClientProperties properties) {
-            List<ClientRegistration> registrations = new ArrayList(OAuth2ClientPropertiesRegistrationAdapter.getClientRegistrations(properties).values());
-            return new InMemoryClientRegistrationRepository(registrations);
-        }
-
-        @Bean
-        @ConditionalOnMissingBean({OAuth2AuthorizedClientService.class})
-        public InMemoryOAuth2AuthorizedClientService authorizedClientService(ClientRegistrationRepository clientRegistrationRepository) {
-            return new InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository);
-        }
-
-        @Bean
-        @ConditionalOnMissingBean
-        public OAuth2AuthorizedClientProvider oAuth2AuthorizedClientProvider() {
-            return OAuth2AuthorizedClientProviderBuilder.builder()
-                .clientCredentials()
-                .password()
-                .build();
-        }
-
-        @Bean
-        @ConditionalOnMissingBean
-        public OAuth2AuthorizedClientManager authorizedClientManager(final ClientRegistrationRepository clientRegistrationRepository,
-            final OAuth2AuthorizedClientService authorizedClientService, OAuth2AuthorizedClientProvider oAuth2AuthorizedClientProvider) {
-            AuthorizedClientServiceOAuth2AuthorizedClientManager authorizedClientServiceOAuth2AuthorizedClientManager =
-                new AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientService);
-            authorizedClientServiceOAuth2AuthorizedClientManager.setAuthorizedClientProvider(oAuth2AuthorizedClientProvider);
-            authorizedClientServiceOAuth2AuthorizedClientManager.setContextAttributesMapper(OAuth2AuthorizeRequest::getAttributes);
-            return authorizedClientServiceOAuth2AuthorizedClientManager;
-        }
-
-        @Bean
-        public OAuth2AuthorizeRequest oAuth2AuthorizeRequest() {
-            return OAuth2AuthorizeRequest.withClientRegistrationId(OAUTH2_CLIENT_REGISTRATION_ID)
-                .principal(new AnonymousAuthenticationToken("feignClient", "feignClient",
-                    AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")))
-                .attribute(OAuth2AuthorizationContext.USERNAME_ATTRIBUTE_NAME, oAuth2Username)
-                .attribute(OAuth2AuthorizationContext.PASSWORD_ATTRIBUTE_NAME, oAuth2Password)
-                .build();
-        }
-
-        @Bean
-        public OAuth2FeignRequestInterceptor requestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager,
-            OAuth2AuthorizeRequest oAuth2AuthorizeRequest) {
-            return new OAuth2FeignRequestInterceptor(oAuth2AuthorizedClientManager, oAuth2AuthorizeRequest);
-        }
-    }
-
-    /**
-     * Configuration for external delegated authentication mechanism. This must be provided by the integrator of the SDK in the form of a bean that implements
-     * the interface {@link DelegatedAuthenticationRequestInterceptor}. This authentication method is enabled via the property
-     * <code>content.service.security.delegated</code>.
-     */
-    @Configuration
-    @ConditionalOnProperty("content.service.security.delegated")
-    protected static class DelegatedAuthenticationConfiguration {
-
-        @Bean
-        public DelegatedAuthenticationRequestInterceptor delegatedAuthenticationRequestInterceptor(DelegatedAuthenticationProvider
-            delegatedAuthenticationProvider) {
-            return new DelegatedAuthenticationRequestInterceptor(delegatedAuthenticationProvider);
-        }
-    }
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-auth-rest-api/pom.xml
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-auth-rest-api/pom.xml
@@ -25,6 +25,10 @@
       <artifactId>spring-boot-starter-oauth2-client</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.alfresco</groupId>
+      <artifactId>alfresco-java-rest-api-common</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
     </dependency>

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-auth-rest-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-auth-rest-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
@@ -15,29 +15,104 @@
  */
 package io.swagger.configuration;
 
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
 import feign.auth.BasicAuthRequestInterceptor;
+import java.util.ArrayList;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientPropertiesRegistrationAdapter;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
 
 @Configuration
-@EnableConfigurationProperties
+@EnableConfigurationProperties({OAuth2ClientProperties.class})
 public class ClientConfiguration {
 
-  @Value("${content.service.security.basicAuth.username}")
-  private String basicAuthUsername;
+  @Configuration
+  @ConditionalOnProperty("content.service.security.basicAuth.username")
+  protected static class BasicAuthConfiguration {
 
-  @Value("${content.service.security.basicAuth.password}")
-  private String basicAuthPassword;
+    @Value("${content.service.security.basicAuth.username:#{null}}")
+    private String basicAuthUsername;
+    @Value("${content.service.security.basicAuth.password:#{null}}")
+    private String basicAuthPassword;
 
-  @Bean
-  @ConditionalOnProperty(name = "content.service.security.basicAuth.username")
-  public BasicAuthRequestInterceptor basicAuthRequestInterceptor() {
-    return new BasicAuthRequestInterceptor(this.basicAuthUsername, this.basicAuthPassword);
+    @Bean
+    @ConditionalOnProperty("content.service.security.basicAuth.username")
+    public BasicAuthRequestInterceptor basicAuthRequestInterceptor() {
+      return new BasicAuthRequestInterceptor(this.basicAuthUsername, this.basicAuthPassword);
+    }
   }
 
+  @Configuration
+  @ConditionalOnProperty("spring.security.oauth2.client.registration.alfresco-rest-api.provider")
+  protected static class OAuth2Configuration {
+
+    @Bean
+    @ConditionalOnMissingBean({ClientRegistrationRepository.class})
+    public InMemoryClientRegistrationRepository clientRegistrationRepository(OAuth2ClientProperties properties) {
+      List<ClientRegistration> registrations = new ArrayList(OAuth2ClientPropertiesRegistrationAdapter.getClientRegistrations(properties).values());
+      return new InMemoryClientRegistrationRepository(registrations);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean({OAuth2AuthorizedClientService.class})
+    public InMemoryOAuth2AuthorizedClientService authorizedClientService(ClientRegistrationRepository clientRegistrationRepository) {
+      return new InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public OAuth2AuthorizedClientManager authorizedClientManager(final ClientRegistrationRepository clientRegistrationRepository,
+          final OAuth2AuthorizedClientService authorizedClientService) {
+      return new AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientService);
+    }
+
+    @Bean
+    public OAuth2FeignRequestInterceptor requestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager) {
+      return new OAuth2FeignRequestInterceptor(oAuth2AuthorizedClientManager,
+              OAuth2AuthorizeRequest.withClientRegistrationId("alfresco-rest-api")
+                      .principal(new AnonymousAuthenticationToken("feignClient", "feignClient", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")))
+                      .build());
+    }
+
+    public class OAuth2FeignRequestInterceptor implements RequestInterceptor {
+
+      private final OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager;
+      private final OAuth2AuthorizeRequest oAuth2AuthorizeRequest;
+
+      public OAuth2FeignRequestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager, OAuth2AuthorizeRequest oAuth2AuthorizeRequest) {
+        this.oAuth2AuthorizedClientManager = oAuth2AuthorizedClientManager;
+        this.oAuth2AuthorizeRequest = oAuth2AuthorizeRequest;
+      }
+
+      @Override
+      public void apply(RequestTemplate template) {
+        template.header(AUTHORIZATION,getAuthorizationToken());
+      }
+
+      private String getAuthorizationToken() {
+        final OAuth2AccessToken accessToken = oAuth2AuthorizedClientManager.authorize(oAuth2AuthorizeRequest).getAccessToken();
+        return String.format("%s %s", accessToken.getTokenType().getValue(), accessToken.getTokenValue());
+      }
+    }
+  }
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-auth-rest-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-auth-rest-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
@@ -15,13 +15,12 @@
  */
 package io.swagger.configuration;
 
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-
-import feign.RequestInterceptor;
-import feign.RequestTemplate;
 import feign.auth.BasicAuthRequestInterceptor;
 import java.util.ArrayList;
 import java.util.List;
+import org.alfresco.rest.sdk.feign.DelegatedAuthenticationProvider;
+import org.alfresco.rest.sdk.feign.DelegatedAuthenticationRequestInterceptor;
+import org.alfresco.rest.sdk.feign.oauth2.OAuth2FeignRequestInterceptor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -34,85 +33,129 @@ import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.OAuth2AuthorizationContext;
 import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProvider;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
-import org.springframework.security.oauth2.core.OAuth2AccessToken;
 
+/**
+ * Feign client Spring configuration that provides support for different authentication methods. Currently, supported methods are:
+ * <ul>
+ *     <li>Basic Authentication</li>
+ *     <li>OAuth2 - Client credentials flow</li>
+ *     <li>OAuth2 - Password flow</li>
+ *     <li>Delegated (external) authentication</li>
+ * </ul>
+ */
 @Configuration
 @EnableConfigurationProperties({OAuth2ClientProperties.class})
 public class ClientConfiguration {
 
-  @Configuration
-  @ConditionalOnProperty("content.service.security.basicAuth.username")
-  protected static class BasicAuthConfiguration {
-
-    @Value("${content.service.security.basicAuth.username:#{null}}")
-    private String basicAuthUsername;
-    @Value("${content.service.security.basicAuth.password:#{null}}")
-    private String basicAuthPassword;
-
-    @Bean
+    /**
+     * Configuration for basic authentication. It configures a {@link BasicAuthRequestInterceptor} that uses the credentials configured in the properties
+     * <code>content.service.security.basicAuth.username</code> and <code>content.service.security.basicAuth.password</code>.
+     */
+    @Configuration
     @ConditionalOnProperty("content.service.security.basicAuth.username")
-    public BasicAuthRequestInterceptor basicAuthRequestInterceptor() {
-      return new BasicAuthRequestInterceptor(this.basicAuthUsername, this.basicAuthPassword);
-    }
-  }
+    protected static class BasicAuthConfiguration {
 
-  @Configuration
-  @ConditionalOnProperty("spring.security.oauth2.client.registration.alfresco-rest-api.provider")
-  protected static class OAuth2Configuration {
+        @Value("${content.service.security.basicAuth.username:#{null}}")
+        private String basicAuthUsername;
+        @Value("${content.service.security.basicAuth.password:#{null}}")
+        private String basicAuthPassword;
 
-    @Bean
-    @ConditionalOnMissingBean({ClientRegistrationRepository.class})
-    public InMemoryClientRegistrationRepository clientRegistrationRepository(OAuth2ClientProperties properties) {
-      List<ClientRegistration> registrations = new ArrayList(OAuth2ClientPropertiesRegistrationAdapter.getClientRegistrations(properties).values());
-      return new InMemoryClientRegistrationRepository(registrations);
+        @Bean
+        @ConditionalOnProperty("content.service.security.basicAuth.username")
+        public BasicAuthRequestInterceptor basicAuthRequestInterceptor() {
+            return new BasicAuthRequestInterceptor(this.basicAuthUsername, this.basicAuthPassword);
+        }
     }
 
-    @Bean
-    @ConditionalOnMissingBean({OAuth2AuthorizedClientService.class})
-    public InMemoryOAuth2AuthorizedClientService authorizedClientService(ClientRegistrationRepository clientRegistrationRepository) {
-      return new InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository);
+    /**
+     * Configuration for OAuth2 authentication flows. It configures a {@link OAuth2FeignRequestInterceptor} that retrieves the access token and generates the
+     * authorization header with the bearer. This is based in the OAuth2 support provided by the Spring Security module. So, the configuration must be done
+     * using the corresponding properties. The configuration of the client must be done using the properties
+     * <code>spring.security.oauth2.client.registration.alfresco-rest-api.xxxx</code>.
+     */
+    @Configuration
+    @ConditionalOnProperty("spring.security.oauth2.client.registration.alfresco-rest-api.provider")
+    protected static class OAuth2Configuration {
+
+        private static final String OAUTH2_CLIENT_REGISTRATION_ID = "alfresco-rest-api";
+
+        @Value("${spring.security.oauth2.client.registration.alfresco-rest-api.username:#{null}}")
+        private String oAuth2Username;
+        @Value("${spring.security.oauth2.client.registration.alfresco-rest-api.password:#{null}}")
+        private String oAuth2Password;
+
+        @Bean
+        @ConditionalOnMissingBean({ClientRegistrationRepository.class})
+        public InMemoryClientRegistrationRepository clientRegistrationRepository(OAuth2ClientProperties properties) {
+            List<ClientRegistration> registrations = new ArrayList(OAuth2ClientPropertiesRegistrationAdapter.getClientRegistrations(properties).values());
+            return new InMemoryClientRegistrationRepository(registrations);
+        }
+
+        @Bean
+        @ConditionalOnMissingBean({OAuth2AuthorizedClientService.class})
+        public InMemoryOAuth2AuthorizedClientService authorizedClientService(ClientRegistrationRepository clientRegistrationRepository) {
+            return new InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository);
+        }
+
+        @Bean
+        @ConditionalOnMissingBean
+        public OAuth2AuthorizedClientProvider oAuth2AuthorizedClientProvider() {
+            return OAuth2AuthorizedClientProviderBuilder.builder()
+                    .clientCredentials()
+                    .password()
+                    .build();
+        }
+
+        @Bean
+        @ConditionalOnMissingBean
+        public OAuth2AuthorizedClientManager authorizedClientManager(final ClientRegistrationRepository clientRegistrationRepository,
+                final OAuth2AuthorizedClientService authorizedClientService, OAuth2AuthorizedClientProvider oAuth2AuthorizedClientProvider) {
+            AuthorizedClientServiceOAuth2AuthorizedClientManager authorizedClientServiceOAuth2AuthorizedClientManager =
+                    new AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientService);
+            authorizedClientServiceOAuth2AuthorizedClientManager.setAuthorizedClientProvider(oAuth2AuthorizedClientProvider);
+            authorizedClientServiceOAuth2AuthorizedClientManager.setContextAttributesMapper(OAuth2AuthorizeRequest::getAttributes);
+            return authorizedClientServiceOAuth2AuthorizedClientManager;
+        }
+
+        @Bean
+        public OAuth2AuthorizeRequest oAuth2AuthorizeRequest() {
+            return OAuth2AuthorizeRequest.withClientRegistrationId(OAUTH2_CLIENT_REGISTRATION_ID)
+                    .principal(new AnonymousAuthenticationToken("feignClient", "feignClient",
+                            AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")))
+                    .attribute(OAuth2AuthorizationContext.USERNAME_ATTRIBUTE_NAME, oAuth2Username)
+                    .attribute(OAuth2AuthorizationContext.PASSWORD_ATTRIBUTE_NAME, oAuth2Password)
+                    .build();
+        }
+
+        @Bean
+        public OAuth2FeignRequestInterceptor requestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager,
+                OAuth2AuthorizeRequest oAuth2AuthorizeRequest) {
+            return new OAuth2FeignRequestInterceptor(oAuth2AuthorizedClientManager, oAuth2AuthorizeRequest);
+        }
     }
 
-    @Bean
-    @ConditionalOnMissingBean
-    public OAuth2AuthorizedClientManager authorizedClientManager(final ClientRegistrationRepository clientRegistrationRepository,
-          final OAuth2AuthorizedClientService authorizedClientService) {
-      return new AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientService);
+    /**
+     * Configuration for external delegated authentication mechanism. This must be provided by the integrator of the SDK in the form of a bean that implements
+     * the interface {@link DelegatedAuthenticationRequestInterceptor}. This authentication method is enabled via the property
+     * <code>content.service.security.delegated</code>.
+     */
+    @Configuration
+    @ConditionalOnProperty("content.service.security.delegated")
+    protected static class DelegatedAuthenticationConfiguration {
+
+        @Bean
+        public DelegatedAuthenticationRequestInterceptor delegatedAuthenticationRequestInterceptor(DelegatedAuthenticationProvider
+                delegatedAuthenticationProvider) {
+            return new DelegatedAuthenticationRequestInterceptor(delegatedAuthenticationProvider);
+        }
     }
-
-    @Bean
-    public OAuth2FeignRequestInterceptor requestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager) {
-      return new OAuth2FeignRequestInterceptor(oAuth2AuthorizedClientManager,
-              OAuth2AuthorizeRequest.withClientRegistrationId("alfresco-rest-api")
-                      .principal(new AnonymousAuthenticationToken("feignClient", "feignClient", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")))
-                      .build());
-    }
-
-    public class OAuth2FeignRequestInterceptor implements RequestInterceptor {
-
-      private final OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager;
-      private final OAuth2AuthorizeRequest oAuth2AuthorizeRequest;
-
-      public OAuth2FeignRequestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager, OAuth2AuthorizeRequest oAuth2AuthorizeRequest) {
-        this.oAuth2AuthorizedClientManager = oAuth2AuthorizedClientManager;
-        this.oAuth2AuthorizeRequest = oAuth2AuthorizeRequest;
-      }
-
-      @Override
-      public void apply(RequestTemplate template) {
-        template.header(AUTHORIZATION,getAuthorizationToken());
-      }
-
-      private String getAuthorizationToken() {
-        final OAuth2AccessToken accessToken = oAuth2AuthorizedClientManager.authorize(oAuth2AuthorizeRequest).getAccessToken();
-        return String.format("%s %s", accessToken.getTokenType().getValue(), accessToken.getTokenValue());
-      }
-    }
-  }
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-auth-rest-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-auth-rest-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
@@ -15,33 +15,11 @@
  */
 package io.swagger.configuration;
 
-import feign.auth.BasicAuthRequestInterceptor;
-import java.util.ArrayList;
-import java.util.List;
-import org.alfresco.rest.sdk.feign.DelegatedAuthenticationProvider;
-import org.alfresco.rest.sdk.feign.DelegatedAuthenticationRequestInterceptor;
-import org.alfresco.rest.sdk.feign.oauth2.OAuth2FeignRequestInterceptor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
-import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientPropertiesRegistrationAdapter;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
+import org.alfresco.rest.sdk.feign.config.BasicAuthConfiguration;
+import org.alfresco.rest.sdk.feign.config.DelegatedAuthenticationConfiguration;
+import org.alfresco.rest.sdk.feign.config.OAuth2Configuration;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.authentication.AnonymousAuthenticationToken;
-import org.springframework.security.core.authority.AuthorityUtils;
-import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
-import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService;
-import org.springframework.security.oauth2.client.OAuth2AuthorizationContext;
-import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProvider;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
-import org.springframework.security.oauth2.client.registration.ClientRegistration;
-import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
-import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.context.annotation.Import;
 
 /**
  * Feign client Spring configuration that provides support for different authentication methods. Currently, supported methods are:
@@ -53,109 +31,7 @@ import org.springframework.security.oauth2.client.registration.InMemoryClientReg
  * </ul>
  */
 @Configuration
-@EnableConfigurationProperties({OAuth2ClientProperties.class})
+@Import({BasicAuthConfiguration.class, OAuth2Configuration.class, DelegatedAuthenticationConfiguration.class})
 public class ClientConfiguration {
 
-    /**
-     * Configuration for basic authentication. It configures a {@link BasicAuthRequestInterceptor} that uses the credentials configured in the properties
-     * <code>content.service.security.basicAuth.username</code> and <code>content.service.security.basicAuth.password</code>.
-     */
-    @Configuration
-    @ConditionalOnProperty("content.service.security.basicAuth.username")
-    protected static class BasicAuthConfiguration {
-
-        @Value("${content.service.security.basicAuth.username:#{null}}")
-        private String basicAuthUsername;
-        @Value("${content.service.security.basicAuth.password:#{null}}")
-        private String basicAuthPassword;
-
-        @Bean
-        @ConditionalOnProperty("content.service.security.basicAuth.username")
-        public BasicAuthRequestInterceptor basicAuthRequestInterceptor() {
-            return new BasicAuthRequestInterceptor(this.basicAuthUsername, this.basicAuthPassword);
-        }
-    }
-
-    /**
-     * Configuration for OAuth2 authentication flows. It configures a {@link OAuth2FeignRequestInterceptor} that retrieves the access token and generates the
-     * authorization header with the bearer. This is based in the OAuth2 support provided by the Spring Security module. So, the configuration must be done
-     * using the corresponding properties. The configuration of the client must be done using the properties
-     * <code>spring.security.oauth2.client.registration.alfresco-rest-api.xxxx</code>.
-     */
-    @Configuration
-    @ConditionalOnProperty("spring.security.oauth2.client.registration.alfresco-rest-api.provider")
-    protected static class OAuth2Configuration {
-
-        private static final String OAUTH2_CLIENT_REGISTRATION_ID = "alfresco-rest-api";
-
-        @Value("${spring.security.oauth2.client.registration.alfresco-rest-api.username:#{null}}")
-        private String oAuth2Username;
-        @Value("${spring.security.oauth2.client.registration.alfresco-rest-api.password:#{null}}")
-        private String oAuth2Password;
-
-        @Bean
-        @ConditionalOnMissingBean({ClientRegistrationRepository.class})
-        public InMemoryClientRegistrationRepository clientRegistrationRepository(OAuth2ClientProperties properties) {
-            List<ClientRegistration> registrations = new ArrayList(OAuth2ClientPropertiesRegistrationAdapter.getClientRegistrations(properties).values());
-            return new InMemoryClientRegistrationRepository(registrations);
-        }
-
-        @Bean
-        @ConditionalOnMissingBean({OAuth2AuthorizedClientService.class})
-        public InMemoryOAuth2AuthorizedClientService authorizedClientService(ClientRegistrationRepository clientRegistrationRepository) {
-            return new InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository);
-        }
-
-        @Bean
-        @ConditionalOnMissingBean
-        public OAuth2AuthorizedClientProvider oAuth2AuthorizedClientProvider() {
-            return OAuth2AuthorizedClientProviderBuilder.builder()
-                    .clientCredentials()
-                    .password()
-                    .build();
-        }
-
-        @Bean
-        @ConditionalOnMissingBean
-        public OAuth2AuthorizedClientManager authorizedClientManager(final ClientRegistrationRepository clientRegistrationRepository,
-                final OAuth2AuthorizedClientService authorizedClientService, OAuth2AuthorizedClientProvider oAuth2AuthorizedClientProvider) {
-            AuthorizedClientServiceOAuth2AuthorizedClientManager authorizedClientServiceOAuth2AuthorizedClientManager =
-                    new AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientService);
-            authorizedClientServiceOAuth2AuthorizedClientManager.setAuthorizedClientProvider(oAuth2AuthorizedClientProvider);
-            authorizedClientServiceOAuth2AuthorizedClientManager.setContextAttributesMapper(OAuth2AuthorizeRequest::getAttributes);
-            return authorizedClientServiceOAuth2AuthorizedClientManager;
-        }
-
-        @Bean
-        public OAuth2AuthorizeRequest oAuth2AuthorizeRequest() {
-            return OAuth2AuthorizeRequest.withClientRegistrationId(OAUTH2_CLIENT_REGISTRATION_ID)
-                    .principal(new AnonymousAuthenticationToken("feignClient", "feignClient",
-                            AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")))
-                    .attribute(OAuth2AuthorizationContext.USERNAME_ATTRIBUTE_NAME, oAuth2Username)
-                    .attribute(OAuth2AuthorizationContext.PASSWORD_ATTRIBUTE_NAME, oAuth2Password)
-                    .build();
-        }
-
-        @Bean
-        public OAuth2FeignRequestInterceptor requestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager,
-                OAuth2AuthorizeRequest oAuth2AuthorizeRequest) {
-            return new OAuth2FeignRequestInterceptor(oAuth2AuthorizedClientManager, oAuth2AuthorizeRequest);
-        }
-    }
-
-    /**
-     * Configuration for external delegated authentication mechanism. This must be provided by the integrator of the SDK in the form of a bean that implements
-     * the interface {@link DelegatedAuthenticationRequestInterceptor}. This authentication method is enabled via the property
-     * <code>content.service.security.delegated</code>.
-     */
-    @Configuration
-    @ConditionalOnProperty("content.service.security.delegated")
-    protected static class DelegatedAuthenticationConfiguration {
-
-        @Bean
-        public DelegatedAuthenticationRequestInterceptor delegatedAuthenticationRequestInterceptor(DelegatedAuthenticationProvider
-                delegatedAuthenticationProvider) {
-            return new DelegatedAuthenticationRequestInterceptor(delegatedAuthenticationProvider);
-        }
-    }
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/pom.xml
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/pom.xml
@@ -25,6 +25,10 @@
       <artifactId>spring-boot-starter-oauth2-client</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.alfresco</groupId>
+      <artifactId>alfresco-java-rest-api-common</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
     </dependency>

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
@@ -15,29 +15,104 @@
  */
 package io.swagger.configuration;
 
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
 import feign.auth.BasicAuthRequestInterceptor;
+import java.util.ArrayList;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientPropertiesRegistrationAdapter;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
 
 @Configuration
-@EnableConfigurationProperties
+@EnableConfigurationProperties({OAuth2ClientProperties.class})
 public class ClientConfiguration {
 
-  @Value("${content.service.security.basicAuth.username}")
-  private String basicAuthUsername;
+  @Configuration
+  @ConditionalOnProperty("content.service.security.basicAuth.username")
+  protected static class BasicAuthConfiguration {
 
-  @Value("${content.service.security.basicAuth.password}")
-  private String basicAuthPassword;
+    @Value("${content.service.security.basicAuth.username:#{null}}")
+    private String basicAuthUsername;
+    @Value("${content.service.security.basicAuth.password:#{null}}")
+    private String basicAuthPassword;
 
-  @Bean
-  @ConditionalOnProperty(name = "content.service.security.basicAuth.username")
-  public BasicAuthRequestInterceptor basicAuthRequestInterceptor() {
-    return new BasicAuthRequestInterceptor(this.basicAuthUsername, this.basicAuthPassword);
+    @Bean
+    @ConditionalOnProperty("content.service.security.basicAuth.username")
+    public BasicAuthRequestInterceptor basicAuthRequestInterceptor() {
+      return new BasicAuthRequestInterceptor(this.basicAuthUsername, this.basicAuthPassword);
+    }
   }
 
+  @Configuration
+  @ConditionalOnProperty("spring.security.oauth2.client.registration.alfresco-rest-api.provider")
+  protected static class OAuth2Configuration {
+
+    @Bean
+    @ConditionalOnMissingBean({ClientRegistrationRepository.class})
+    public InMemoryClientRegistrationRepository clientRegistrationRepository(OAuth2ClientProperties properties) {
+      List<ClientRegistration> registrations = new ArrayList(OAuth2ClientPropertiesRegistrationAdapter.getClientRegistrations(properties).values());
+      return new InMemoryClientRegistrationRepository(registrations);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean({OAuth2AuthorizedClientService.class})
+    public InMemoryOAuth2AuthorizedClientService authorizedClientService(ClientRegistrationRepository clientRegistrationRepository) {
+      return new InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public OAuth2AuthorizedClientManager authorizedClientManager(final ClientRegistrationRepository clientRegistrationRepository,
+          final OAuth2AuthorizedClientService authorizedClientService) {
+      return new AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientService);
+    }
+
+    @Bean
+    public OAuth2FeignRequestInterceptor requestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager) {
+      return new OAuth2FeignRequestInterceptor(oAuth2AuthorizedClientManager,
+              OAuth2AuthorizeRequest.withClientRegistrationId("alfresco-rest-api")
+                      .principal(new AnonymousAuthenticationToken("feignClient", "feignClient", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")))
+                      .build());
+    }
+
+    public class OAuth2FeignRequestInterceptor implements RequestInterceptor {
+
+      private final OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager;
+      private final OAuth2AuthorizeRequest oAuth2AuthorizeRequest;
+
+      public OAuth2FeignRequestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager, OAuth2AuthorizeRequest oAuth2AuthorizeRequest) {
+        this.oAuth2AuthorizedClientManager = oAuth2AuthorizedClientManager;
+        this.oAuth2AuthorizeRequest = oAuth2AuthorizeRequest;
+      }
+
+      @Override
+      public void apply(RequestTemplate template) {
+        template.header(AUTHORIZATION,getAuthorizationToken());
+      }
+
+      private String getAuthorizationToken() {
+        final OAuth2AccessToken accessToken = oAuth2AuthorizedClientManager.authorize(oAuth2AuthorizeRequest).getAccessToken();
+        return String.format("%s %s", accessToken.getTokenType().getValue(), accessToken.getTokenValue());
+      }
+    }
+  }
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
@@ -15,13 +15,12 @@
  */
 package io.swagger.configuration;
 
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-
-import feign.RequestInterceptor;
-import feign.RequestTemplate;
 import feign.auth.BasicAuthRequestInterceptor;
 import java.util.ArrayList;
 import java.util.List;
+import org.alfresco.rest.sdk.feign.DelegatedAuthenticationProvider;
+import org.alfresco.rest.sdk.feign.DelegatedAuthenticationRequestInterceptor;
+import org.alfresco.rest.sdk.feign.oauth2.OAuth2FeignRequestInterceptor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -34,85 +33,129 @@ import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.OAuth2AuthorizationContext;
 import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProvider;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
-import org.springframework.security.oauth2.core.OAuth2AccessToken;
 
+/**
+ * Feign client Spring configuration that provides support for different authentication methods. Currently, supported methods are:
+ * <ul>
+ *     <li>Basic Authentication</li>
+ *     <li>OAuth2 - Client credentials flow</li>
+ *     <li>OAuth2 - Password flow</li>
+ *     <li>Delegated (external) authentication</li>
+ * </ul>
+ */
 @Configuration
 @EnableConfigurationProperties({OAuth2ClientProperties.class})
 public class ClientConfiguration {
 
-  @Configuration
-  @ConditionalOnProperty("content.service.security.basicAuth.username")
-  protected static class BasicAuthConfiguration {
-
-    @Value("${content.service.security.basicAuth.username:#{null}}")
-    private String basicAuthUsername;
-    @Value("${content.service.security.basicAuth.password:#{null}}")
-    private String basicAuthPassword;
-
-    @Bean
+    /**
+     * Configuration for basic authentication. It configures a {@link BasicAuthRequestInterceptor} that uses the credentials configured in the properties
+     * <code>content.service.security.basicAuth.username</code> and <code>content.service.security.basicAuth.password</code>.
+     */
+    @Configuration
     @ConditionalOnProperty("content.service.security.basicAuth.username")
-    public BasicAuthRequestInterceptor basicAuthRequestInterceptor() {
-      return new BasicAuthRequestInterceptor(this.basicAuthUsername, this.basicAuthPassword);
-    }
-  }
+    protected static class BasicAuthConfiguration {
 
-  @Configuration
-  @ConditionalOnProperty("spring.security.oauth2.client.registration.alfresco-rest-api.provider")
-  protected static class OAuth2Configuration {
+        @Value("${content.service.security.basicAuth.username:#{null}}")
+        private String basicAuthUsername;
+        @Value("${content.service.security.basicAuth.password:#{null}}")
+        private String basicAuthPassword;
 
-    @Bean
-    @ConditionalOnMissingBean({ClientRegistrationRepository.class})
-    public InMemoryClientRegistrationRepository clientRegistrationRepository(OAuth2ClientProperties properties) {
-      List<ClientRegistration> registrations = new ArrayList(OAuth2ClientPropertiesRegistrationAdapter.getClientRegistrations(properties).values());
-      return new InMemoryClientRegistrationRepository(registrations);
+        @Bean
+        @ConditionalOnProperty("content.service.security.basicAuth.username")
+        public BasicAuthRequestInterceptor basicAuthRequestInterceptor() {
+            return new BasicAuthRequestInterceptor(this.basicAuthUsername, this.basicAuthPassword);
+        }
     }
 
-    @Bean
-    @ConditionalOnMissingBean({OAuth2AuthorizedClientService.class})
-    public InMemoryOAuth2AuthorizedClientService authorizedClientService(ClientRegistrationRepository clientRegistrationRepository) {
-      return new InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository);
+    /**
+     * Configuration for OAuth2 authentication flows. It configures a {@link OAuth2FeignRequestInterceptor} that retrieves the access token and generates the
+     * authorization header with the bearer. This is based in the OAuth2 support provided by the Spring Security module. So, the configuration must be done
+     * using the corresponding properties. The configuration of the client must be done using the properties
+     * <code>spring.security.oauth2.client.registration.alfresco-rest-api.xxxx</code>.
+     */
+    @Configuration
+    @ConditionalOnProperty("spring.security.oauth2.client.registration.alfresco-rest-api.provider")
+    protected static class OAuth2Configuration {
+
+        private static final String OAUTH2_CLIENT_REGISTRATION_ID = "alfresco-rest-api";
+
+        @Value("${spring.security.oauth2.client.registration.alfresco-rest-api.username:#{null}}")
+        private String oAuth2Username;
+        @Value("${spring.security.oauth2.client.registration.alfresco-rest-api.password:#{null}}")
+        private String oAuth2Password;
+
+        @Bean
+        @ConditionalOnMissingBean({ClientRegistrationRepository.class})
+        public InMemoryClientRegistrationRepository clientRegistrationRepository(OAuth2ClientProperties properties) {
+            List<ClientRegistration> registrations = new ArrayList(OAuth2ClientPropertiesRegistrationAdapter.getClientRegistrations(properties).values());
+            return new InMemoryClientRegistrationRepository(registrations);
+        }
+
+        @Bean
+        @ConditionalOnMissingBean({OAuth2AuthorizedClientService.class})
+        public InMemoryOAuth2AuthorizedClientService authorizedClientService(ClientRegistrationRepository clientRegistrationRepository) {
+            return new InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository);
+        }
+
+        @Bean
+        @ConditionalOnMissingBean
+        public OAuth2AuthorizedClientProvider oAuth2AuthorizedClientProvider() {
+            return OAuth2AuthorizedClientProviderBuilder.builder()
+                    .clientCredentials()
+                    .password()
+                    .build();
+        }
+
+        @Bean
+        @ConditionalOnMissingBean
+        public OAuth2AuthorizedClientManager authorizedClientManager(final ClientRegistrationRepository clientRegistrationRepository,
+                final OAuth2AuthorizedClientService authorizedClientService, OAuth2AuthorizedClientProvider oAuth2AuthorizedClientProvider) {
+            AuthorizedClientServiceOAuth2AuthorizedClientManager authorizedClientServiceOAuth2AuthorizedClientManager =
+                    new AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientService);
+            authorizedClientServiceOAuth2AuthorizedClientManager.setAuthorizedClientProvider(oAuth2AuthorizedClientProvider);
+            authorizedClientServiceOAuth2AuthorizedClientManager.setContextAttributesMapper(OAuth2AuthorizeRequest::getAttributes);
+            return authorizedClientServiceOAuth2AuthorizedClientManager;
+        }
+
+        @Bean
+        public OAuth2AuthorizeRequest oAuth2AuthorizeRequest() {
+            return OAuth2AuthorizeRequest.withClientRegistrationId(OAUTH2_CLIENT_REGISTRATION_ID)
+                    .principal(new AnonymousAuthenticationToken("feignClient", "feignClient",
+                            AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")))
+                    .attribute(OAuth2AuthorizationContext.USERNAME_ATTRIBUTE_NAME, oAuth2Username)
+                    .attribute(OAuth2AuthorizationContext.PASSWORD_ATTRIBUTE_NAME, oAuth2Password)
+                    .build();
+        }
+
+        @Bean
+        public OAuth2FeignRequestInterceptor requestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager,
+                OAuth2AuthorizeRequest oAuth2AuthorizeRequest) {
+            return new OAuth2FeignRequestInterceptor(oAuth2AuthorizedClientManager, oAuth2AuthorizeRequest);
+        }
     }
 
-    @Bean
-    @ConditionalOnMissingBean
-    public OAuth2AuthorizedClientManager authorizedClientManager(final ClientRegistrationRepository clientRegistrationRepository,
-          final OAuth2AuthorizedClientService authorizedClientService) {
-      return new AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientService);
+    /**
+     * Configuration for external delegated authentication mechanism. This must be provided by the integrator of the SDK in the form of a bean that implements
+     * the interface {@link DelegatedAuthenticationRequestInterceptor}. This authentication method is enabled via the property
+     * <code>content.service.security.delegated</code>.
+     */
+    @Configuration
+    @ConditionalOnProperty("content.service.security.delegated")
+    protected static class DelegatedAuthenticationConfiguration {
+
+        @Bean
+        public DelegatedAuthenticationRequestInterceptor delegatedAuthenticationRequestInterceptor(DelegatedAuthenticationProvider
+                delegatedAuthenticationProvider) {
+            return new DelegatedAuthenticationRequestInterceptor(delegatedAuthenticationProvider);
+        }
     }
-
-    @Bean
-    public OAuth2FeignRequestInterceptor requestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager) {
-      return new OAuth2FeignRequestInterceptor(oAuth2AuthorizedClientManager,
-              OAuth2AuthorizeRequest.withClientRegistrationId("alfresco-rest-api")
-                      .principal(new AnonymousAuthenticationToken("feignClient", "feignClient", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")))
-                      .build());
-    }
-
-    public class OAuth2FeignRequestInterceptor implements RequestInterceptor {
-
-      private final OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager;
-      private final OAuth2AuthorizeRequest oAuth2AuthorizeRequest;
-
-      public OAuth2FeignRequestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager, OAuth2AuthorizeRequest oAuth2AuthorizeRequest) {
-        this.oAuth2AuthorizedClientManager = oAuth2AuthorizedClientManager;
-        this.oAuth2AuthorizeRequest = oAuth2AuthorizeRequest;
-      }
-
-      @Override
-      public void apply(RequestTemplate template) {
-        template.header(AUTHORIZATION,getAuthorizationToken());
-      }
-
-      private String getAuthorizationToken() {
-        final OAuth2AccessToken accessToken = oAuth2AuthorizedClientManager.authorize(oAuth2AuthorizeRequest).getAccessToken();
-        return String.format("%s %s", accessToken.getTokenType().getValue(), accessToken.getTokenValue());
-      }
-    }
-  }
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
@@ -15,33 +15,11 @@
  */
 package io.swagger.configuration;
 
-import feign.auth.BasicAuthRequestInterceptor;
-import java.util.ArrayList;
-import java.util.List;
-import org.alfresco.rest.sdk.feign.DelegatedAuthenticationProvider;
-import org.alfresco.rest.sdk.feign.DelegatedAuthenticationRequestInterceptor;
-import org.alfresco.rest.sdk.feign.oauth2.OAuth2FeignRequestInterceptor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
-import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientPropertiesRegistrationAdapter;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
+import org.alfresco.rest.sdk.feign.config.BasicAuthConfiguration;
+import org.alfresco.rest.sdk.feign.config.DelegatedAuthenticationConfiguration;
+import org.alfresco.rest.sdk.feign.config.OAuth2Configuration;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.authentication.AnonymousAuthenticationToken;
-import org.springframework.security.core.authority.AuthorityUtils;
-import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
-import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService;
-import org.springframework.security.oauth2.client.OAuth2AuthorizationContext;
-import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProvider;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
-import org.springframework.security.oauth2.client.registration.ClientRegistration;
-import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
-import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.context.annotation.Import;
 
 /**
  * Feign client Spring configuration that provides support for different authentication methods. Currently, supported methods are:
@@ -53,109 +31,7 @@ import org.springframework.security.oauth2.client.registration.InMemoryClientReg
  * </ul>
  */
 @Configuration
-@EnableConfigurationProperties({OAuth2ClientProperties.class})
+@Import({BasicAuthConfiguration.class, OAuth2Configuration.class, DelegatedAuthenticationConfiguration.class})
 public class ClientConfiguration {
 
-    /**
-     * Configuration for basic authentication. It configures a {@link BasicAuthRequestInterceptor} that uses the credentials configured in the properties
-     * <code>content.service.security.basicAuth.username</code> and <code>content.service.security.basicAuth.password</code>.
-     */
-    @Configuration
-    @ConditionalOnProperty("content.service.security.basicAuth.username")
-    protected static class BasicAuthConfiguration {
-
-        @Value("${content.service.security.basicAuth.username:#{null}}")
-        private String basicAuthUsername;
-        @Value("${content.service.security.basicAuth.password:#{null}}")
-        private String basicAuthPassword;
-
-        @Bean
-        @ConditionalOnProperty("content.service.security.basicAuth.username")
-        public BasicAuthRequestInterceptor basicAuthRequestInterceptor() {
-            return new BasicAuthRequestInterceptor(this.basicAuthUsername, this.basicAuthPassword);
-        }
-    }
-
-    /**
-     * Configuration for OAuth2 authentication flows. It configures a {@link OAuth2FeignRequestInterceptor} that retrieves the access token and generates the
-     * authorization header with the bearer. This is based in the OAuth2 support provided by the Spring Security module. So, the configuration must be done
-     * using the corresponding properties. The configuration of the client must be done using the properties
-     * <code>spring.security.oauth2.client.registration.alfresco-rest-api.xxxx</code>.
-     */
-    @Configuration
-    @ConditionalOnProperty("spring.security.oauth2.client.registration.alfresco-rest-api.provider")
-    protected static class OAuth2Configuration {
-
-        private static final String OAUTH2_CLIENT_REGISTRATION_ID = "alfresco-rest-api";
-
-        @Value("${spring.security.oauth2.client.registration.alfresco-rest-api.username:#{null}}")
-        private String oAuth2Username;
-        @Value("${spring.security.oauth2.client.registration.alfresco-rest-api.password:#{null}}")
-        private String oAuth2Password;
-
-        @Bean
-        @ConditionalOnMissingBean({ClientRegistrationRepository.class})
-        public InMemoryClientRegistrationRepository clientRegistrationRepository(OAuth2ClientProperties properties) {
-            List<ClientRegistration> registrations = new ArrayList(OAuth2ClientPropertiesRegistrationAdapter.getClientRegistrations(properties).values());
-            return new InMemoryClientRegistrationRepository(registrations);
-        }
-
-        @Bean
-        @ConditionalOnMissingBean({OAuth2AuthorizedClientService.class})
-        public InMemoryOAuth2AuthorizedClientService authorizedClientService(ClientRegistrationRepository clientRegistrationRepository) {
-            return new InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository);
-        }
-
-        @Bean
-        @ConditionalOnMissingBean
-        public OAuth2AuthorizedClientProvider oAuth2AuthorizedClientProvider() {
-            return OAuth2AuthorizedClientProviderBuilder.builder()
-                    .clientCredentials()
-                    .password()
-                    .build();
-        }
-
-        @Bean
-        @ConditionalOnMissingBean
-        public OAuth2AuthorizedClientManager authorizedClientManager(final ClientRegistrationRepository clientRegistrationRepository,
-                final OAuth2AuthorizedClientService authorizedClientService, OAuth2AuthorizedClientProvider oAuth2AuthorizedClientProvider) {
-            AuthorizedClientServiceOAuth2AuthorizedClientManager authorizedClientServiceOAuth2AuthorizedClientManager =
-                    new AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientService);
-            authorizedClientServiceOAuth2AuthorizedClientManager.setAuthorizedClientProvider(oAuth2AuthorizedClientProvider);
-            authorizedClientServiceOAuth2AuthorizedClientManager.setContextAttributesMapper(OAuth2AuthorizeRequest::getAttributes);
-            return authorizedClientServiceOAuth2AuthorizedClientManager;
-        }
-
-        @Bean
-        public OAuth2AuthorizeRequest oAuth2AuthorizeRequest() {
-            return OAuth2AuthorizeRequest.withClientRegistrationId(OAUTH2_CLIENT_REGISTRATION_ID)
-                    .principal(new AnonymousAuthenticationToken("feignClient", "feignClient",
-                            AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")))
-                    .attribute(OAuth2AuthorizationContext.USERNAME_ATTRIBUTE_NAME, oAuth2Username)
-                    .attribute(OAuth2AuthorizationContext.PASSWORD_ATTRIBUTE_NAME, oAuth2Password)
-                    .build();
-        }
-
-        @Bean
-        public OAuth2FeignRequestInterceptor requestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager,
-                OAuth2AuthorizeRequest oAuth2AuthorizeRequest) {
-            return new OAuth2FeignRequestInterceptor(oAuth2AuthorizedClientManager, oAuth2AuthorizeRequest);
-        }
-    }
-
-    /**
-     * Configuration for external delegated authentication mechanism. This must be provided by the integrator of the SDK in the form of a bean that implements
-     * the interface {@link DelegatedAuthenticationRequestInterceptor}. This authentication method is enabled via the property
-     * <code>content.service.security.delegated</code>.
-     */
-    @Configuration
-    @ConditionalOnProperty("content.service.security.delegated")
-    protected static class DelegatedAuthenticationConfiguration {
-
-        @Bean
-        public DelegatedAuthenticationRequestInterceptor delegatedAuthenticationRequestInterceptor(DelegatedAuthenticationProvider
-                delegatedAuthenticationProvider) {
-            return new DelegatedAuthenticationRequestInterceptor(delegatedAuthenticationProvider);
-        }
-    }
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-discovery-rest-api/pom.xml
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-discovery-rest-api/pom.xml
@@ -25,6 +25,10 @@
       <artifactId>spring-boot-starter-oauth2-client</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.alfresco</groupId>
+      <artifactId>alfresco-java-rest-api-common</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
     </dependency>

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-discovery-rest-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-discovery-rest-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
@@ -15,29 +15,104 @@
  */
 package io.swagger.configuration;
 
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
 import feign.auth.BasicAuthRequestInterceptor;
+import java.util.ArrayList;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientPropertiesRegistrationAdapter;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
 
 @Configuration
-@EnableConfigurationProperties
+@EnableConfigurationProperties({OAuth2ClientProperties.class})
 public class ClientConfiguration {
 
-  @Value("${content.service.security.basicAuth.username}")
-  private String basicAuthUsername;
+  @Configuration
+  @ConditionalOnProperty("content.service.security.basicAuth.username")
+  protected static class BasicAuthConfiguration {
 
-  @Value("${content.service.security.basicAuth.password}")
-  private String basicAuthPassword;
+    @Value("${content.service.security.basicAuth.username:#{null}}")
+    private String basicAuthUsername;
+    @Value("${content.service.security.basicAuth.password:#{null}}")
+    private String basicAuthPassword;
 
-  @Bean
-  @ConditionalOnProperty(name = "content.service.security.basicAuth.username")
-  public BasicAuthRequestInterceptor basicAuthRequestInterceptor() {
-    return new BasicAuthRequestInterceptor(this.basicAuthUsername, this.basicAuthPassword);
+    @Bean
+    @ConditionalOnProperty("content.service.security.basicAuth.username")
+    public BasicAuthRequestInterceptor basicAuthRequestInterceptor() {
+      return new BasicAuthRequestInterceptor(this.basicAuthUsername, this.basicAuthPassword);
+    }
   }
 
+  @Configuration
+  @ConditionalOnProperty("spring.security.oauth2.client.registration.alfresco-rest-api.provider")
+  protected static class OAuth2Configuration {
+
+    @Bean
+    @ConditionalOnMissingBean({ClientRegistrationRepository.class})
+    public InMemoryClientRegistrationRepository clientRegistrationRepository(OAuth2ClientProperties properties) {
+      List<ClientRegistration> registrations = new ArrayList(OAuth2ClientPropertiesRegistrationAdapter.getClientRegistrations(properties).values());
+      return new InMemoryClientRegistrationRepository(registrations);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean({OAuth2AuthorizedClientService.class})
+    public InMemoryOAuth2AuthorizedClientService authorizedClientService(ClientRegistrationRepository clientRegistrationRepository) {
+      return new InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public OAuth2AuthorizedClientManager authorizedClientManager(final ClientRegistrationRepository clientRegistrationRepository,
+          final OAuth2AuthorizedClientService authorizedClientService) {
+      return new AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientService);
+    }
+
+    @Bean
+    public OAuth2FeignRequestInterceptor requestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager) {
+      return new OAuth2FeignRequestInterceptor(oAuth2AuthorizedClientManager,
+              OAuth2AuthorizeRequest.withClientRegistrationId("alfresco-rest-api")
+                      .principal(new AnonymousAuthenticationToken("feignClient", "feignClient", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")))
+                      .build());
+    }
+
+    public class OAuth2FeignRequestInterceptor implements RequestInterceptor {
+
+      private final OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager;
+      private final OAuth2AuthorizeRequest oAuth2AuthorizeRequest;
+
+      public OAuth2FeignRequestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager, OAuth2AuthorizeRequest oAuth2AuthorizeRequest) {
+        this.oAuth2AuthorizedClientManager = oAuth2AuthorizedClientManager;
+        this.oAuth2AuthorizeRequest = oAuth2AuthorizeRequest;
+      }
+
+      @Override
+      public void apply(RequestTemplate template) {
+        template.header(AUTHORIZATION,getAuthorizationToken());
+      }
+
+      private String getAuthorizationToken() {
+        final OAuth2AccessToken accessToken = oAuth2AuthorizedClientManager.authorize(oAuth2AuthorizeRequest).getAccessToken();
+        return String.format("%s %s", accessToken.getTokenType().getValue(), accessToken.getTokenValue());
+      }
+    }
+  }
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-discovery-rest-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-discovery-rest-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
@@ -15,13 +15,12 @@
  */
 package io.swagger.configuration;
 
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-
-import feign.RequestInterceptor;
-import feign.RequestTemplate;
 import feign.auth.BasicAuthRequestInterceptor;
 import java.util.ArrayList;
 import java.util.List;
+import org.alfresco.rest.sdk.feign.DelegatedAuthenticationProvider;
+import org.alfresco.rest.sdk.feign.DelegatedAuthenticationRequestInterceptor;
+import org.alfresco.rest.sdk.feign.oauth2.OAuth2FeignRequestInterceptor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -34,85 +33,129 @@ import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.OAuth2AuthorizationContext;
 import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProvider;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
-import org.springframework.security.oauth2.core.OAuth2AccessToken;
 
+/**
+ * Feign client Spring configuration that provides support for different authentication methods. Currently, supported methods are:
+ * <ul>
+ *     <li>Basic Authentication</li>
+ *     <li>OAuth2 - Client credentials flow</li>
+ *     <li>OAuth2 - Password flow</li>
+ *     <li>Delegated (external) authentication</li>
+ * </ul>
+ */
 @Configuration
 @EnableConfigurationProperties({OAuth2ClientProperties.class})
 public class ClientConfiguration {
 
-  @Configuration
-  @ConditionalOnProperty("content.service.security.basicAuth.username")
-  protected static class BasicAuthConfiguration {
-
-    @Value("${content.service.security.basicAuth.username:#{null}}")
-    private String basicAuthUsername;
-    @Value("${content.service.security.basicAuth.password:#{null}}")
-    private String basicAuthPassword;
-
-    @Bean
+    /**
+     * Configuration for basic authentication. It configures a {@link BasicAuthRequestInterceptor} that uses the credentials configured in the properties
+     * <code>content.service.security.basicAuth.username</code> and <code>content.service.security.basicAuth.password</code>.
+     */
+    @Configuration
     @ConditionalOnProperty("content.service.security.basicAuth.username")
-    public BasicAuthRequestInterceptor basicAuthRequestInterceptor() {
-      return new BasicAuthRequestInterceptor(this.basicAuthUsername, this.basicAuthPassword);
-    }
-  }
+    protected static class BasicAuthConfiguration {
 
-  @Configuration
-  @ConditionalOnProperty("spring.security.oauth2.client.registration.alfresco-rest-api.provider")
-  protected static class OAuth2Configuration {
+        @Value("${content.service.security.basicAuth.username:#{null}}")
+        private String basicAuthUsername;
+        @Value("${content.service.security.basicAuth.password:#{null}}")
+        private String basicAuthPassword;
 
-    @Bean
-    @ConditionalOnMissingBean({ClientRegistrationRepository.class})
-    public InMemoryClientRegistrationRepository clientRegistrationRepository(OAuth2ClientProperties properties) {
-      List<ClientRegistration> registrations = new ArrayList(OAuth2ClientPropertiesRegistrationAdapter.getClientRegistrations(properties).values());
-      return new InMemoryClientRegistrationRepository(registrations);
+        @Bean
+        @ConditionalOnProperty("content.service.security.basicAuth.username")
+        public BasicAuthRequestInterceptor basicAuthRequestInterceptor() {
+            return new BasicAuthRequestInterceptor(this.basicAuthUsername, this.basicAuthPassword);
+        }
     }
 
-    @Bean
-    @ConditionalOnMissingBean({OAuth2AuthorizedClientService.class})
-    public InMemoryOAuth2AuthorizedClientService authorizedClientService(ClientRegistrationRepository clientRegistrationRepository) {
-      return new InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository);
+    /**
+     * Configuration for OAuth2 authentication flows. It configures a {@link OAuth2FeignRequestInterceptor} that retrieves the access token and generates the
+     * authorization header with the bearer. This is based in the OAuth2 support provided by the Spring Security module. So, the configuration must be done
+     * using the corresponding properties. The configuration of the client must be done using the properties
+     * <code>spring.security.oauth2.client.registration.alfresco-rest-api.xxxx</code>.
+     */
+    @Configuration
+    @ConditionalOnProperty("spring.security.oauth2.client.registration.alfresco-rest-api.provider")
+    protected static class OAuth2Configuration {
+
+        private static final String OAUTH2_CLIENT_REGISTRATION_ID = "alfresco-rest-api";
+
+        @Value("${spring.security.oauth2.client.registration.alfresco-rest-api.username:#{null}}")
+        private String oAuth2Username;
+        @Value("${spring.security.oauth2.client.registration.alfresco-rest-api.password:#{null}}")
+        private String oAuth2Password;
+
+        @Bean
+        @ConditionalOnMissingBean({ClientRegistrationRepository.class})
+        public InMemoryClientRegistrationRepository clientRegistrationRepository(OAuth2ClientProperties properties) {
+            List<ClientRegistration> registrations = new ArrayList(OAuth2ClientPropertiesRegistrationAdapter.getClientRegistrations(properties).values());
+            return new InMemoryClientRegistrationRepository(registrations);
+        }
+
+        @Bean
+        @ConditionalOnMissingBean({OAuth2AuthorizedClientService.class})
+        public InMemoryOAuth2AuthorizedClientService authorizedClientService(ClientRegistrationRepository clientRegistrationRepository) {
+            return new InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository);
+        }
+
+        @Bean
+        @ConditionalOnMissingBean
+        public OAuth2AuthorizedClientProvider oAuth2AuthorizedClientProvider() {
+            return OAuth2AuthorizedClientProviderBuilder.builder()
+                    .clientCredentials()
+                    .password()
+                    .build();
+        }
+
+        @Bean
+        @ConditionalOnMissingBean
+        public OAuth2AuthorizedClientManager authorizedClientManager(final ClientRegistrationRepository clientRegistrationRepository,
+                final OAuth2AuthorizedClientService authorizedClientService, OAuth2AuthorizedClientProvider oAuth2AuthorizedClientProvider) {
+            AuthorizedClientServiceOAuth2AuthorizedClientManager authorizedClientServiceOAuth2AuthorizedClientManager =
+                    new AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientService);
+            authorizedClientServiceOAuth2AuthorizedClientManager.setAuthorizedClientProvider(oAuth2AuthorizedClientProvider);
+            authorizedClientServiceOAuth2AuthorizedClientManager.setContextAttributesMapper(OAuth2AuthorizeRequest::getAttributes);
+            return authorizedClientServiceOAuth2AuthorizedClientManager;
+        }
+
+        @Bean
+        public OAuth2AuthorizeRequest oAuth2AuthorizeRequest() {
+            return OAuth2AuthorizeRequest.withClientRegistrationId(OAUTH2_CLIENT_REGISTRATION_ID)
+                    .principal(new AnonymousAuthenticationToken("feignClient", "feignClient",
+                            AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")))
+                    .attribute(OAuth2AuthorizationContext.USERNAME_ATTRIBUTE_NAME, oAuth2Username)
+                    .attribute(OAuth2AuthorizationContext.PASSWORD_ATTRIBUTE_NAME, oAuth2Password)
+                    .build();
+        }
+
+        @Bean
+        public OAuth2FeignRequestInterceptor requestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager,
+                OAuth2AuthorizeRequest oAuth2AuthorizeRequest) {
+            return new OAuth2FeignRequestInterceptor(oAuth2AuthorizedClientManager, oAuth2AuthorizeRequest);
+        }
     }
 
-    @Bean
-    @ConditionalOnMissingBean
-    public OAuth2AuthorizedClientManager authorizedClientManager(final ClientRegistrationRepository clientRegistrationRepository,
-          final OAuth2AuthorizedClientService authorizedClientService) {
-      return new AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientService);
+    /**
+     * Configuration for external delegated authentication mechanism. This must be provided by the integrator of the SDK in the form of a bean that implements
+     * the interface {@link DelegatedAuthenticationRequestInterceptor}. This authentication method is enabled via the property
+     * <code>content.service.security.delegated</code>.
+     */
+    @Configuration
+    @ConditionalOnProperty("content.service.security.delegated")
+    protected static class DelegatedAuthenticationConfiguration {
+
+        @Bean
+        public DelegatedAuthenticationRequestInterceptor delegatedAuthenticationRequestInterceptor(DelegatedAuthenticationProvider
+                delegatedAuthenticationProvider) {
+            return new DelegatedAuthenticationRequestInterceptor(delegatedAuthenticationProvider);
+        }
     }
-
-    @Bean
-    public OAuth2FeignRequestInterceptor requestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager) {
-      return new OAuth2FeignRequestInterceptor(oAuth2AuthorizedClientManager,
-              OAuth2AuthorizeRequest.withClientRegistrationId("alfresco-rest-api")
-                      .principal(new AnonymousAuthenticationToken("feignClient", "feignClient", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")))
-                      .build());
-    }
-
-    public class OAuth2FeignRequestInterceptor implements RequestInterceptor {
-
-      private final OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager;
-      private final OAuth2AuthorizeRequest oAuth2AuthorizeRequest;
-
-      public OAuth2FeignRequestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager, OAuth2AuthorizeRequest oAuth2AuthorizeRequest) {
-        this.oAuth2AuthorizedClientManager = oAuth2AuthorizedClientManager;
-        this.oAuth2AuthorizeRequest = oAuth2AuthorizeRequest;
-      }
-
-      @Override
-      public void apply(RequestTemplate template) {
-        template.header(AUTHORIZATION,getAuthorizationToken());
-      }
-
-      private String getAuthorizationToken() {
-        final OAuth2AccessToken accessToken = oAuth2AuthorizedClientManager.authorize(oAuth2AuthorizeRequest).getAccessToken();
-        return String.format("%s %s", accessToken.getTokenType().getValue(), accessToken.getTokenValue());
-      }
-    }
-  }
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-discovery-rest-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-discovery-rest-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
@@ -15,33 +15,11 @@
  */
 package io.swagger.configuration;
 
-import feign.auth.BasicAuthRequestInterceptor;
-import java.util.ArrayList;
-import java.util.List;
-import org.alfresco.rest.sdk.feign.DelegatedAuthenticationProvider;
-import org.alfresco.rest.sdk.feign.DelegatedAuthenticationRequestInterceptor;
-import org.alfresco.rest.sdk.feign.oauth2.OAuth2FeignRequestInterceptor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
-import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientPropertiesRegistrationAdapter;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
+import org.alfresco.rest.sdk.feign.config.BasicAuthConfiguration;
+import org.alfresco.rest.sdk.feign.config.DelegatedAuthenticationConfiguration;
+import org.alfresco.rest.sdk.feign.config.OAuth2Configuration;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.authentication.AnonymousAuthenticationToken;
-import org.springframework.security.core.authority.AuthorityUtils;
-import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
-import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService;
-import org.springframework.security.oauth2.client.OAuth2AuthorizationContext;
-import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProvider;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
-import org.springframework.security.oauth2.client.registration.ClientRegistration;
-import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
-import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.context.annotation.Import;
 
 /**
  * Feign client Spring configuration that provides support for different authentication methods. Currently, supported methods are:
@@ -53,109 +31,7 @@ import org.springframework.security.oauth2.client.registration.InMemoryClientReg
  * </ul>
  */
 @Configuration
-@EnableConfigurationProperties({OAuth2ClientProperties.class})
+@Import({BasicAuthConfiguration.class, OAuth2Configuration.class, DelegatedAuthenticationConfiguration.class})
 public class ClientConfiguration {
 
-    /**
-     * Configuration for basic authentication. It configures a {@link BasicAuthRequestInterceptor} that uses the credentials configured in the properties
-     * <code>content.service.security.basicAuth.username</code> and <code>content.service.security.basicAuth.password</code>.
-     */
-    @Configuration
-    @ConditionalOnProperty("content.service.security.basicAuth.username")
-    protected static class BasicAuthConfiguration {
-
-        @Value("${content.service.security.basicAuth.username:#{null}}")
-        private String basicAuthUsername;
-        @Value("${content.service.security.basicAuth.password:#{null}}")
-        private String basicAuthPassword;
-
-        @Bean
-        @ConditionalOnProperty("content.service.security.basicAuth.username")
-        public BasicAuthRequestInterceptor basicAuthRequestInterceptor() {
-            return new BasicAuthRequestInterceptor(this.basicAuthUsername, this.basicAuthPassword);
-        }
-    }
-
-    /**
-     * Configuration for OAuth2 authentication flows. It configures a {@link OAuth2FeignRequestInterceptor} that retrieves the access token and generates the
-     * authorization header with the bearer. This is based in the OAuth2 support provided by the Spring Security module. So, the configuration must be done
-     * using the corresponding properties. The configuration of the client must be done using the properties
-     * <code>spring.security.oauth2.client.registration.alfresco-rest-api.xxxx</code>.
-     */
-    @Configuration
-    @ConditionalOnProperty("spring.security.oauth2.client.registration.alfresco-rest-api.provider")
-    protected static class OAuth2Configuration {
-
-        private static final String OAUTH2_CLIENT_REGISTRATION_ID = "alfresco-rest-api";
-
-        @Value("${spring.security.oauth2.client.registration.alfresco-rest-api.username:#{null}}")
-        private String oAuth2Username;
-        @Value("${spring.security.oauth2.client.registration.alfresco-rest-api.password:#{null}}")
-        private String oAuth2Password;
-
-        @Bean
-        @ConditionalOnMissingBean({ClientRegistrationRepository.class})
-        public InMemoryClientRegistrationRepository clientRegistrationRepository(OAuth2ClientProperties properties) {
-            List<ClientRegistration> registrations = new ArrayList(OAuth2ClientPropertiesRegistrationAdapter.getClientRegistrations(properties).values());
-            return new InMemoryClientRegistrationRepository(registrations);
-        }
-
-        @Bean
-        @ConditionalOnMissingBean({OAuth2AuthorizedClientService.class})
-        public InMemoryOAuth2AuthorizedClientService authorizedClientService(ClientRegistrationRepository clientRegistrationRepository) {
-            return new InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository);
-        }
-
-        @Bean
-        @ConditionalOnMissingBean
-        public OAuth2AuthorizedClientProvider oAuth2AuthorizedClientProvider() {
-            return OAuth2AuthorizedClientProviderBuilder.builder()
-                    .clientCredentials()
-                    .password()
-                    .build();
-        }
-
-        @Bean
-        @ConditionalOnMissingBean
-        public OAuth2AuthorizedClientManager authorizedClientManager(final ClientRegistrationRepository clientRegistrationRepository,
-                final OAuth2AuthorizedClientService authorizedClientService, OAuth2AuthorizedClientProvider oAuth2AuthorizedClientProvider) {
-            AuthorizedClientServiceOAuth2AuthorizedClientManager authorizedClientServiceOAuth2AuthorizedClientManager =
-                    new AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientService);
-            authorizedClientServiceOAuth2AuthorizedClientManager.setAuthorizedClientProvider(oAuth2AuthorizedClientProvider);
-            authorizedClientServiceOAuth2AuthorizedClientManager.setContextAttributesMapper(OAuth2AuthorizeRequest::getAttributes);
-            return authorizedClientServiceOAuth2AuthorizedClientManager;
-        }
-
-        @Bean
-        public OAuth2AuthorizeRequest oAuth2AuthorizeRequest() {
-            return OAuth2AuthorizeRequest.withClientRegistrationId(OAUTH2_CLIENT_REGISTRATION_ID)
-                    .principal(new AnonymousAuthenticationToken("feignClient", "feignClient",
-                            AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")))
-                    .attribute(OAuth2AuthorizationContext.USERNAME_ATTRIBUTE_NAME, oAuth2Username)
-                    .attribute(OAuth2AuthorizationContext.PASSWORD_ATTRIBUTE_NAME, oAuth2Password)
-                    .build();
-        }
-
-        @Bean
-        public OAuth2FeignRequestInterceptor requestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager,
-                OAuth2AuthorizeRequest oAuth2AuthorizeRequest) {
-            return new OAuth2FeignRequestInterceptor(oAuth2AuthorizedClientManager, oAuth2AuthorizeRequest);
-        }
-    }
-
-    /**
-     * Configuration for external delegated authentication mechanism. This must be provided by the integrator of the SDK in the form of a bean that implements
-     * the interface {@link DelegatedAuthenticationRequestInterceptor}. This authentication method is enabled via the property
-     * <code>content.service.security.delegated</code>.
-     */
-    @Configuration
-    @ConditionalOnProperty("content.service.security.delegated")
-    protected static class DelegatedAuthenticationConfiguration {
-
-        @Bean
-        public DelegatedAuthenticationRequestInterceptor delegatedAuthenticationRequestInterceptor(DelegatedAuthenticationProvider
-                delegatedAuthenticationProvider) {
-            return new DelegatedAuthenticationRequestInterceptor(delegatedAuthenticationProvider);
-        }
-    }
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-classification-rest-api/pom.xml
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-classification-rest-api/pom.xml
@@ -25,6 +25,10 @@
       <artifactId>spring-boot-starter-oauth2-client</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.alfresco</groupId>
+      <artifactId>alfresco-java-rest-api-common</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
     </dependency>

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-classification-rest-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-classification-rest-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
@@ -15,29 +15,104 @@
  */
 package io.swagger.configuration;
 
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
 import feign.auth.BasicAuthRequestInterceptor;
+import java.util.ArrayList;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientPropertiesRegistrationAdapter;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
 
 @Configuration
-@EnableConfigurationProperties
+@EnableConfigurationProperties({OAuth2ClientProperties.class})
 public class ClientConfiguration {
 
-  @Value("${content.service.security.basicAuth.username}")
-  private String basicAuthUsername;
+  @Configuration
+  @ConditionalOnProperty("content.service.security.basicAuth.username")
+  protected static class BasicAuthConfiguration {
 
-  @Value("${content.service.security.basicAuth.password}")
-  private String basicAuthPassword;
+    @Value("${content.service.security.basicAuth.username:#{null}}")
+    private String basicAuthUsername;
+    @Value("${content.service.security.basicAuth.password:#{null}}")
+    private String basicAuthPassword;
 
-  @Bean
-  @ConditionalOnProperty(name = "content.service.security.basicAuth.username")
-  public BasicAuthRequestInterceptor basicAuthRequestInterceptor() {
-    return new BasicAuthRequestInterceptor(this.basicAuthUsername, this.basicAuthPassword);
+    @Bean
+    @ConditionalOnProperty("content.service.security.basicAuth.username")
+    public BasicAuthRequestInterceptor basicAuthRequestInterceptor() {
+      return new BasicAuthRequestInterceptor(this.basicAuthUsername, this.basicAuthPassword);
+    }
   }
 
+  @Configuration
+  @ConditionalOnProperty("spring.security.oauth2.client.registration.alfresco-rest-api.provider")
+  protected static class OAuth2Configuration {
+
+    @Bean
+    @ConditionalOnMissingBean({ClientRegistrationRepository.class})
+    public InMemoryClientRegistrationRepository clientRegistrationRepository(OAuth2ClientProperties properties) {
+      List<ClientRegistration> registrations = new ArrayList(OAuth2ClientPropertiesRegistrationAdapter.getClientRegistrations(properties).values());
+      return new InMemoryClientRegistrationRepository(registrations);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean({OAuth2AuthorizedClientService.class})
+    public InMemoryOAuth2AuthorizedClientService authorizedClientService(ClientRegistrationRepository clientRegistrationRepository) {
+      return new InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public OAuth2AuthorizedClientManager authorizedClientManager(final ClientRegistrationRepository clientRegistrationRepository,
+          final OAuth2AuthorizedClientService authorizedClientService) {
+      return new AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientService);
+    }
+
+    @Bean
+    public OAuth2FeignRequestInterceptor requestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager) {
+      return new OAuth2FeignRequestInterceptor(oAuth2AuthorizedClientManager,
+              OAuth2AuthorizeRequest.withClientRegistrationId("alfresco-rest-api")
+                      .principal(new AnonymousAuthenticationToken("feignClient", "feignClient", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")))
+                      .build());
+    }
+
+    public class OAuth2FeignRequestInterceptor implements RequestInterceptor {
+
+      private final OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager;
+      private final OAuth2AuthorizeRequest oAuth2AuthorizeRequest;
+
+      public OAuth2FeignRequestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager, OAuth2AuthorizeRequest oAuth2AuthorizeRequest) {
+        this.oAuth2AuthorizedClientManager = oAuth2AuthorizedClientManager;
+        this.oAuth2AuthorizeRequest = oAuth2AuthorizeRequest;
+      }
+
+      @Override
+      public void apply(RequestTemplate template) {
+        template.header(AUTHORIZATION,getAuthorizationToken());
+      }
+
+      private String getAuthorizationToken() {
+        final OAuth2AccessToken accessToken = oAuth2AuthorizedClientManager.authorize(oAuth2AuthorizeRequest).getAccessToken();
+        return String.format("%s %s", accessToken.getTokenType().getValue(), accessToken.getTokenValue());
+      }
+    }
+  }
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-classification-rest-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-classification-rest-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
@@ -15,13 +15,12 @@
  */
 package io.swagger.configuration;
 
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-
-import feign.RequestInterceptor;
-import feign.RequestTemplate;
 import feign.auth.BasicAuthRequestInterceptor;
 import java.util.ArrayList;
 import java.util.List;
+import org.alfresco.rest.sdk.feign.DelegatedAuthenticationProvider;
+import org.alfresco.rest.sdk.feign.DelegatedAuthenticationRequestInterceptor;
+import org.alfresco.rest.sdk.feign.oauth2.OAuth2FeignRequestInterceptor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -34,85 +33,129 @@ import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.OAuth2AuthorizationContext;
 import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProvider;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
-import org.springframework.security.oauth2.core.OAuth2AccessToken;
 
+/**
+ * Feign client Spring configuration that provides support for different authentication methods. Currently, supported methods are:
+ * <ul>
+ *     <li>Basic Authentication</li>
+ *     <li>OAuth2 - Client credentials flow</li>
+ *     <li>OAuth2 - Password flow</li>
+ *     <li>Delegated (external) authentication</li>
+ * </ul>
+ */
 @Configuration
 @EnableConfigurationProperties({OAuth2ClientProperties.class})
 public class ClientConfiguration {
 
-  @Configuration
-  @ConditionalOnProperty("content.service.security.basicAuth.username")
-  protected static class BasicAuthConfiguration {
-
-    @Value("${content.service.security.basicAuth.username:#{null}}")
-    private String basicAuthUsername;
-    @Value("${content.service.security.basicAuth.password:#{null}}")
-    private String basicAuthPassword;
-
-    @Bean
+    /**
+     * Configuration for basic authentication. It configures a {@link BasicAuthRequestInterceptor} that uses the credentials configured in the properties
+     * <code>content.service.security.basicAuth.username</code> and <code>content.service.security.basicAuth.password</code>.
+     */
+    @Configuration
     @ConditionalOnProperty("content.service.security.basicAuth.username")
-    public BasicAuthRequestInterceptor basicAuthRequestInterceptor() {
-      return new BasicAuthRequestInterceptor(this.basicAuthUsername, this.basicAuthPassword);
-    }
-  }
+    protected static class BasicAuthConfiguration {
 
-  @Configuration
-  @ConditionalOnProperty("spring.security.oauth2.client.registration.alfresco-rest-api.provider")
-  protected static class OAuth2Configuration {
+        @Value("${content.service.security.basicAuth.username:#{null}}")
+        private String basicAuthUsername;
+        @Value("${content.service.security.basicAuth.password:#{null}}")
+        private String basicAuthPassword;
 
-    @Bean
-    @ConditionalOnMissingBean({ClientRegistrationRepository.class})
-    public InMemoryClientRegistrationRepository clientRegistrationRepository(OAuth2ClientProperties properties) {
-      List<ClientRegistration> registrations = new ArrayList(OAuth2ClientPropertiesRegistrationAdapter.getClientRegistrations(properties).values());
-      return new InMemoryClientRegistrationRepository(registrations);
+        @Bean
+        @ConditionalOnProperty("content.service.security.basicAuth.username")
+        public BasicAuthRequestInterceptor basicAuthRequestInterceptor() {
+            return new BasicAuthRequestInterceptor(this.basicAuthUsername, this.basicAuthPassword);
+        }
     }
 
-    @Bean
-    @ConditionalOnMissingBean({OAuth2AuthorizedClientService.class})
-    public InMemoryOAuth2AuthorizedClientService authorizedClientService(ClientRegistrationRepository clientRegistrationRepository) {
-      return new InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository);
+    /**
+     * Configuration for OAuth2 authentication flows. It configures a {@link OAuth2FeignRequestInterceptor} that retrieves the access token and generates the
+     * authorization header with the bearer. This is based in the OAuth2 support provided by the Spring Security module. So, the configuration must be done
+     * using the corresponding properties. The configuration of the client must be done using the properties
+     * <code>spring.security.oauth2.client.registration.alfresco-rest-api.xxxx</code>.
+     */
+    @Configuration
+    @ConditionalOnProperty("spring.security.oauth2.client.registration.alfresco-rest-api.provider")
+    protected static class OAuth2Configuration {
+
+        private static final String OAUTH2_CLIENT_REGISTRATION_ID = "alfresco-rest-api";
+
+        @Value("${spring.security.oauth2.client.registration.alfresco-rest-api.username:#{null}}")
+        private String oAuth2Username;
+        @Value("${spring.security.oauth2.client.registration.alfresco-rest-api.password:#{null}}")
+        private String oAuth2Password;
+
+        @Bean
+        @ConditionalOnMissingBean({ClientRegistrationRepository.class})
+        public InMemoryClientRegistrationRepository clientRegistrationRepository(OAuth2ClientProperties properties) {
+            List<ClientRegistration> registrations = new ArrayList(OAuth2ClientPropertiesRegistrationAdapter.getClientRegistrations(properties).values());
+            return new InMemoryClientRegistrationRepository(registrations);
+        }
+
+        @Bean
+        @ConditionalOnMissingBean({OAuth2AuthorizedClientService.class})
+        public InMemoryOAuth2AuthorizedClientService authorizedClientService(ClientRegistrationRepository clientRegistrationRepository) {
+            return new InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository);
+        }
+
+        @Bean
+        @ConditionalOnMissingBean
+        public OAuth2AuthorizedClientProvider oAuth2AuthorizedClientProvider() {
+            return OAuth2AuthorizedClientProviderBuilder.builder()
+                    .clientCredentials()
+                    .password()
+                    .build();
+        }
+
+        @Bean
+        @ConditionalOnMissingBean
+        public OAuth2AuthorizedClientManager authorizedClientManager(final ClientRegistrationRepository clientRegistrationRepository,
+                final OAuth2AuthorizedClientService authorizedClientService, OAuth2AuthorizedClientProvider oAuth2AuthorizedClientProvider) {
+            AuthorizedClientServiceOAuth2AuthorizedClientManager authorizedClientServiceOAuth2AuthorizedClientManager =
+                    new AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientService);
+            authorizedClientServiceOAuth2AuthorizedClientManager.setAuthorizedClientProvider(oAuth2AuthorizedClientProvider);
+            authorizedClientServiceOAuth2AuthorizedClientManager.setContextAttributesMapper(OAuth2AuthorizeRequest::getAttributes);
+            return authorizedClientServiceOAuth2AuthorizedClientManager;
+        }
+
+        @Bean
+        public OAuth2AuthorizeRequest oAuth2AuthorizeRequest() {
+            return OAuth2AuthorizeRequest.withClientRegistrationId(OAUTH2_CLIENT_REGISTRATION_ID)
+                    .principal(new AnonymousAuthenticationToken("feignClient", "feignClient",
+                            AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")))
+                    .attribute(OAuth2AuthorizationContext.USERNAME_ATTRIBUTE_NAME, oAuth2Username)
+                    .attribute(OAuth2AuthorizationContext.PASSWORD_ATTRIBUTE_NAME, oAuth2Password)
+                    .build();
+        }
+
+        @Bean
+        public OAuth2FeignRequestInterceptor requestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager,
+                OAuth2AuthorizeRequest oAuth2AuthorizeRequest) {
+            return new OAuth2FeignRequestInterceptor(oAuth2AuthorizedClientManager, oAuth2AuthorizeRequest);
+        }
     }
 
-    @Bean
-    @ConditionalOnMissingBean
-    public OAuth2AuthorizedClientManager authorizedClientManager(final ClientRegistrationRepository clientRegistrationRepository,
-          final OAuth2AuthorizedClientService authorizedClientService) {
-      return new AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientService);
+    /**
+     * Configuration for external delegated authentication mechanism. This must be provided by the integrator of the SDK in the form of a bean that implements
+     * the interface {@link DelegatedAuthenticationRequestInterceptor}. This authentication method is enabled via the property
+     * <code>content.service.security.delegated</code>.
+     */
+    @Configuration
+    @ConditionalOnProperty("content.service.security.delegated")
+    protected static class DelegatedAuthenticationConfiguration {
+
+        @Bean
+        public DelegatedAuthenticationRequestInterceptor delegatedAuthenticationRequestInterceptor(DelegatedAuthenticationProvider
+                delegatedAuthenticationProvider) {
+            return new DelegatedAuthenticationRequestInterceptor(delegatedAuthenticationProvider);
+        }
     }
-
-    @Bean
-    public OAuth2FeignRequestInterceptor requestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager) {
-      return new OAuth2FeignRequestInterceptor(oAuth2AuthorizedClientManager,
-              OAuth2AuthorizeRequest.withClientRegistrationId("alfresco-rest-api")
-                      .principal(new AnonymousAuthenticationToken("feignClient", "feignClient", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")))
-                      .build());
-    }
-
-    public class OAuth2FeignRequestInterceptor implements RequestInterceptor {
-
-      private final OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager;
-      private final OAuth2AuthorizeRequest oAuth2AuthorizeRequest;
-
-      public OAuth2FeignRequestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager, OAuth2AuthorizeRequest oAuth2AuthorizeRequest) {
-        this.oAuth2AuthorizedClientManager = oAuth2AuthorizedClientManager;
-        this.oAuth2AuthorizeRequest = oAuth2AuthorizeRequest;
-      }
-
-      @Override
-      public void apply(RequestTemplate template) {
-        template.header(AUTHORIZATION,getAuthorizationToken());
-      }
-
-      private String getAuthorizationToken() {
-        final OAuth2AccessToken accessToken = oAuth2AuthorizedClientManager.authorize(oAuth2AuthorizeRequest).getAccessToken();
-        return String.format("%s %s", accessToken.getTokenType().getValue(), accessToken.getTokenValue());
-      }
-    }
-  }
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-classification-rest-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-classification-rest-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
@@ -15,33 +15,11 @@
  */
 package io.swagger.configuration;
 
-import feign.auth.BasicAuthRequestInterceptor;
-import java.util.ArrayList;
-import java.util.List;
-import org.alfresco.rest.sdk.feign.DelegatedAuthenticationProvider;
-import org.alfresco.rest.sdk.feign.DelegatedAuthenticationRequestInterceptor;
-import org.alfresco.rest.sdk.feign.oauth2.OAuth2FeignRequestInterceptor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
-import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientPropertiesRegistrationAdapter;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
+import org.alfresco.rest.sdk.feign.config.BasicAuthConfiguration;
+import org.alfresco.rest.sdk.feign.config.DelegatedAuthenticationConfiguration;
+import org.alfresco.rest.sdk.feign.config.OAuth2Configuration;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.authentication.AnonymousAuthenticationToken;
-import org.springframework.security.core.authority.AuthorityUtils;
-import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
-import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService;
-import org.springframework.security.oauth2.client.OAuth2AuthorizationContext;
-import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProvider;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
-import org.springframework.security.oauth2.client.registration.ClientRegistration;
-import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
-import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.context.annotation.Import;
 
 /**
  * Feign client Spring configuration that provides support for different authentication methods. Currently, supported methods are:
@@ -53,109 +31,7 @@ import org.springframework.security.oauth2.client.registration.InMemoryClientReg
  * </ul>
  */
 @Configuration
-@EnableConfigurationProperties({OAuth2ClientProperties.class})
+@Import({BasicAuthConfiguration.class, OAuth2Configuration.class, DelegatedAuthenticationConfiguration.class})
 public class ClientConfiguration {
 
-    /**
-     * Configuration for basic authentication. It configures a {@link BasicAuthRequestInterceptor} that uses the credentials configured in the properties
-     * <code>content.service.security.basicAuth.username</code> and <code>content.service.security.basicAuth.password</code>.
-     */
-    @Configuration
-    @ConditionalOnProperty("content.service.security.basicAuth.username")
-    protected static class BasicAuthConfiguration {
-
-        @Value("${content.service.security.basicAuth.username:#{null}}")
-        private String basicAuthUsername;
-        @Value("${content.service.security.basicAuth.password:#{null}}")
-        private String basicAuthPassword;
-
-        @Bean
-        @ConditionalOnProperty("content.service.security.basicAuth.username")
-        public BasicAuthRequestInterceptor basicAuthRequestInterceptor() {
-            return new BasicAuthRequestInterceptor(this.basicAuthUsername, this.basicAuthPassword);
-        }
-    }
-
-    /**
-     * Configuration for OAuth2 authentication flows. It configures a {@link OAuth2FeignRequestInterceptor} that retrieves the access token and generates the
-     * authorization header with the bearer. This is based in the OAuth2 support provided by the Spring Security module. So, the configuration must be done
-     * using the corresponding properties. The configuration of the client must be done using the properties
-     * <code>spring.security.oauth2.client.registration.alfresco-rest-api.xxxx</code>.
-     */
-    @Configuration
-    @ConditionalOnProperty("spring.security.oauth2.client.registration.alfresco-rest-api.provider")
-    protected static class OAuth2Configuration {
-
-        private static final String OAUTH2_CLIENT_REGISTRATION_ID = "alfresco-rest-api";
-
-        @Value("${spring.security.oauth2.client.registration.alfresco-rest-api.username:#{null}}")
-        private String oAuth2Username;
-        @Value("${spring.security.oauth2.client.registration.alfresco-rest-api.password:#{null}}")
-        private String oAuth2Password;
-
-        @Bean
-        @ConditionalOnMissingBean({ClientRegistrationRepository.class})
-        public InMemoryClientRegistrationRepository clientRegistrationRepository(OAuth2ClientProperties properties) {
-            List<ClientRegistration> registrations = new ArrayList(OAuth2ClientPropertiesRegistrationAdapter.getClientRegistrations(properties).values());
-            return new InMemoryClientRegistrationRepository(registrations);
-        }
-
-        @Bean
-        @ConditionalOnMissingBean({OAuth2AuthorizedClientService.class})
-        public InMemoryOAuth2AuthorizedClientService authorizedClientService(ClientRegistrationRepository clientRegistrationRepository) {
-            return new InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository);
-        }
-
-        @Bean
-        @ConditionalOnMissingBean
-        public OAuth2AuthorizedClientProvider oAuth2AuthorizedClientProvider() {
-            return OAuth2AuthorizedClientProviderBuilder.builder()
-                    .clientCredentials()
-                    .password()
-                    .build();
-        }
-
-        @Bean
-        @ConditionalOnMissingBean
-        public OAuth2AuthorizedClientManager authorizedClientManager(final ClientRegistrationRepository clientRegistrationRepository,
-                final OAuth2AuthorizedClientService authorizedClientService, OAuth2AuthorizedClientProvider oAuth2AuthorizedClientProvider) {
-            AuthorizedClientServiceOAuth2AuthorizedClientManager authorizedClientServiceOAuth2AuthorizedClientManager =
-                    new AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientService);
-            authorizedClientServiceOAuth2AuthorizedClientManager.setAuthorizedClientProvider(oAuth2AuthorizedClientProvider);
-            authorizedClientServiceOAuth2AuthorizedClientManager.setContextAttributesMapper(OAuth2AuthorizeRequest::getAttributes);
-            return authorizedClientServiceOAuth2AuthorizedClientManager;
-        }
-
-        @Bean
-        public OAuth2AuthorizeRequest oAuth2AuthorizeRequest() {
-            return OAuth2AuthorizeRequest.withClientRegistrationId(OAUTH2_CLIENT_REGISTRATION_ID)
-                    .principal(new AnonymousAuthenticationToken("feignClient", "feignClient",
-                            AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")))
-                    .attribute(OAuth2AuthorizationContext.USERNAME_ATTRIBUTE_NAME, oAuth2Username)
-                    .attribute(OAuth2AuthorizationContext.PASSWORD_ATTRIBUTE_NAME, oAuth2Password)
-                    .build();
-        }
-
-        @Bean
-        public OAuth2FeignRequestInterceptor requestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager,
-                OAuth2AuthorizeRequest oAuth2AuthorizeRequest) {
-            return new OAuth2FeignRequestInterceptor(oAuth2AuthorizedClientManager, oAuth2AuthorizeRequest);
-        }
-    }
-
-    /**
-     * Configuration for external delegated authentication mechanism. This must be provided by the integrator of the SDK in the form of a bean that implements
-     * the interface {@link DelegatedAuthenticationRequestInterceptor}. This authentication method is enabled via the property
-     * <code>content.service.security.delegated</code>.
-     */
-    @Configuration
-    @ConditionalOnProperty("content.service.security.delegated")
-    protected static class DelegatedAuthenticationConfiguration {
-
-        @Bean
-        public DelegatedAuthenticationRequestInterceptor delegatedAuthenticationRequestInterceptor(DelegatedAuthenticationProvider
-                delegatedAuthenticationProvider) {
-            return new DelegatedAuthenticationRequestInterceptor(delegatedAuthenticationProvider);
-        }
-    }
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-core-rest-api/pom.xml
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-core-rest-api/pom.xml
@@ -25,6 +25,10 @@
       <artifactId>spring-boot-starter-oauth2-client</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.alfresco</groupId>
+      <artifactId>alfresco-java-rest-api-common</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
     </dependency>

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-core-rest-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-core-rest-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
@@ -15,29 +15,104 @@
  */
 package io.swagger.configuration;
 
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
 import feign.auth.BasicAuthRequestInterceptor;
+import java.util.ArrayList;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientPropertiesRegistrationAdapter;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
 
 @Configuration
-@EnableConfigurationProperties
+@EnableConfigurationProperties({OAuth2ClientProperties.class})
 public class ClientConfiguration {
 
-  @Value("${content.service.security.basicAuth.username}")
-  private String basicAuthUsername;
+  @Configuration
+  @ConditionalOnProperty("content.service.security.basicAuth.username")
+  protected static class BasicAuthConfiguration {
 
-  @Value("${content.service.security.basicAuth.password}")
-  private String basicAuthPassword;
+    @Value("${content.service.security.basicAuth.username:#{null}}")
+    private String basicAuthUsername;
+    @Value("${content.service.security.basicAuth.password:#{null}}")
+    private String basicAuthPassword;
 
-  @Bean
-  @ConditionalOnProperty(name = "content.service.security.basicAuth.username")
-  public BasicAuthRequestInterceptor basicAuthRequestInterceptor() {
-    return new BasicAuthRequestInterceptor(this.basicAuthUsername, this.basicAuthPassword);
+    @Bean
+    @ConditionalOnProperty("content.service.security.basicAuth.username")
+    public BasicAuthRequestInterceptor basicAuthRequestInterceptor() {
+      return new BasicAuthRequestInterceptor(this.basicAuthUsername, this.basicAuthPassword);
+    }
   }
 
+  @Configuration
+  @ConditionalOnProperty("spring.security.oauth2.client.registration.alfresco-rest-api.provider")
+  protected static class OAuth2Configuration {
+
+    @Bean
+    @ConditionalOnMissingBean({ClientRegistrationRepository.class})
+    public InMemoryClientRegistrationRepository clientRegistrationRepository(OAuth2ClientProperties properties) {
+      List<ClientRegistration> registrations = new ArrayList(OAuth2ClientPropertiesRegistrationAdapter.getClientRegistrations(properties).values());
+      return new InMemoryClientRegistrationRepository(registrations);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean({OAuth2AuthorizedClientService.class})
+    public InMemoryOAuth2AuthorizedClientService authorizedClientService(ClientRegistrationRepository clientRegistrationRepository) {
+      return new InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public OAuth2AuthorizedClientManager authorizedClientManager(final ClientRegistrationRepository clientRegistrationRepository,
+          final OAuth2AuthorizedClientService authorizedClientService) {
+      return new AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientService);
+    }
+
+    @Bean
+    public OAuth2FeignRequestInterceptor requestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager) {
+      return new OAuth2FeignRequestInterceptor(oAuth2AuthorizedClientManager,
+              OAuth2AuthorizeRequest.withClientRegistrationId("alfresco-rest-api")
+                      .principal(new AnonymousAuthenticationToken("feignClient", "feignClient", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")))
+                      .build());
+    }
+
+    public class OAuth2FeignRequestInterceptor implements RequestInterceptor {
+
+      private final OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager;
+      private final OAuth2AuthorizeRequest oAuth2AuthorizeRequest;
+
+      public OAuth2FeignRequestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager, OAuth2AuthorizeRequest oAuth2AuthorizeRequest) {
+        this.oAuth2AuthorizedClientManager = oAuth2AuthorizedClientManager;
+        this.oAuth2AuthorizeRequest = oAuth2AuthorizeRequest;
+      }
+
+      @Override
+      public void apply(RequestTemplate template) {
+        template.header(AUTHORIZATION,getAuthorizationToken());
+      }
+
+      private String getAuthorizationToken() {
+        final OAuth2AccessToken accessToken = oAuth2AuthorizedClientManager.authorize(oAuth2AuthorizeRequest).getAccessToken();
+        return String.format("%s %s", accessToken.getTokenType().getValue(), accessToken.getTokenValue());
+      }
+    }
+  }
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-core-rest-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-core-rest-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
@@ -15,13 +15,12 @@
  */
 package io.swagger.configuration;
 
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-
-import feign.RequestInterceptor;
-import feign.RequestTemplate;
 import feign.auth.BasicAuthRequestInterceptor;
 import java.util.ArrayList;
 import java.util.List;
+import org.alfresco.rest.sdk.feign.DelegatedAuthenticationProvider;
+import org.alfresco.rest.sdk.feign.DelegatedAuthenticationRequestInterceptor;
+import org.alfresco.rest.sdk.feign.oauth2.OAuth2FeignRequestInterceptor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -34,85 +33,129 @@ import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.OAuth2AuthorizationContext;
 import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProvider;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
-import org.springframework.security.oauth2.core.OAuth2AccessToken;
 
+/**
+ * Feign client Spring configuration that provides support for different authentication methods. Currently, supported methods are:
+ * <ul>
+ *     <li>Basic Authentication</li>
+ *     <li>OAuth2 - Client credentials flow</li>
+ *     <li>OAuth2 - Password flow</li>
+ *     <li>Delegated (external) authentication</li>
+ * </ul>
+ */
 @Configuration
 @EnableConfigurationProperties({OAuth2ClientProperties.class})
 public class ClientConfiguration {
 
-  @Configuration
-  @ConditionalOnProperty("content.service.security.basicAuth.username")
-  protected static class BasicAuthConfiguration {
-
-    @Value("${content.service.security.basicAuth.username:#{null}}")
-    private String basicAuthUsername;
-    @Value("${content.service.security.basicAuth.password:#{null}}")
-    private String basicAuthPassword;
-
-    @Bean
+    /**
+     * Configuration for basic authentication. It configures a {@link BasicAuthRequestInterceptor} that uses the credentials configured in the properties
+     * <code>content.service.security.basicAuth.username</code> and <code>content.service.security.basicAuth.password</code>.
+     */
+    @Configuration
     @ConditionalOnProperty("content.service.security.basicAuth.username")
-    public BasicAuthRequestInterceptor basicAuthRequestInterceptor() {
-      return new BasicAuthRequestInterceptor(this.basicAuthUsername, this.basicAuthPassword);
-    }
-  }
+    protected static class BasicAuthConfiguration {
 
-  @Configuration
-  @ConditionalOnProperty("spring.security.oauth2.client.registration.alfresco-rest-api.provider")
-  protected static class OAuth2Configuration {
+        @Value("${content.service.security.basicAuth.username:#{null}}")
+        private String basicAuthUsername;
+        @Value("${content.service.security.basicAuth.password:#{null}}")
+        private String basicAuthPassword;
 
-    @Bean
-    @ConditionalOnMissingBean({ClientRegistrationRepository.class})
-    public InMemoryClientRegistrationRepository clientRegistrationRepository(OAuth2ClientProperties properties) {
-      List<ClientRegistration> registrations = new ArrayList(OAuth2ClientPropertiesRegistrationAdapter.getClientRegistrations(properties).values());
-      return new InMemoryClientRegistrationRepository(registrations);
+        @Bean
+        @ConditionalOnProperty("content.service.security.basicAuth.username")
+        public BasicAuthRequestInterceptor basicAuthRequestInterceptor() {
+            return new BasicAuthRequestInterceptor(this.basicAuthUsername, this.basicAuthPassword);
+        }
     }
 
-    @Bean
-    @ConditionalOnMissingBean({OAuth2AuthorizedClientService.class})
-    public InMemoryOAuth2AuthorizedClientService authorizedClientService(ClientRegistrationRepository clientRegistrationRepository) {
-      return new InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository);
+    /**
+     * Configuration for OAuth2 authentication flows. It configures a {@link OAuth2FeignRequestInterceptor} that retrieves the access token and generates the
+     * authorization header with the bearer. This is based in the OAuth2 support provided by the Spring Security module. So, the configuration must be done
+     * using the corresponding properties. The configuration of the client must be done using the properties
+     * <code>spring.security.oauth2.client.registration.alfresco-rest-api.xxxx</code>.
+     */
+    @Configuration
+    @ConditionalOnProperty("spring.security.oauth2.client.registration.alfresco-rest-api.provider")
+    protected static class OAuth2Configuration {
+
+        private static final String OAUTH2_CLIENT_REGISTRATION_ID = "alfresco-rest-api";
+
+        @Value("${spring.security.oauth2.client.registration.alfresco-rest-api.username:#{null}}")
+        private String oAuth2Username;
+        @Value("${spring.security.oauth2.client.registration.alfresco-rest-api.password:#{null}}")
+        private String oAuth2Password;
+
+        @Bean
+        @ConditionalOnMissingBean({ClientRegistrationRepository.class})
+        public InMemoryClientRegistrationRepository clientRegistrationRepository(OAuth2ClientProperties properties) {
+            List<ClientRegistration> registrations = new ArrayList(OAuth2ClientPropertiesRegistrationAdapter.getClientRegistrations(properties).values());
+            return new InMemoryClientRegistrationRepository(registrations);
+        }
+
+        @Bean
+        @ConditionalOnMissingBean({OAuth2AuthorizedClientService.class})
+        public InMemoryOAuth2AuthorizedClientService authorizedClientService(ClientRegistrationRepository clientRegistrationRepository) {
+            return new InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository);
+        }
+
+        @Bean
+        @ConditionalOnMissingBean
+        public OAuth2AuthorizedClientProvider oAuth2AuthorizedClientProvider() {
+            return OAuth2AuthorizedClientProviderBuilder.builder()
+                    .clientCredentials()
+                    .password()
+                    .build();
+        }
+
+        @Bean
+        @ConditionalOnMissingBean
+        public OAuth2AuthorizedClientManager authorizedClientManager(final ClientRegistrationRepository clientRegistrationRepository,
+                final OAuth2AuthorizedClientService authorizedClientService, OAuth2AuthorizedClientProvider oAuth2AuthorizedClientProvider) {
+            AuthorizedClientServiceOAuth2AuthorizedClientManager authorizedClientServiceOAuth2AuthorizedClientManager =
+                    new AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientService);
+            authorizedClientServiceOAuth2AuthorizedClientManager.setAuthorizedClientProvider(oAuth2AuthorizedClientProvider);
+            authorizedClientServiceOAuth2AuthorizedClientManager.setContextAttributesMapper(OAuth2AuthorizeRequest::getAttributes);
+            return authorizedClientServiceOAuth2AuthorizedClientManager;
+        }
+
+        @Bean
+        public OAuth2AuthorizeRequest oAuth2AuthorizeRequest() {
+            return OAuth2AuthorizeRequest.withClientRegistrationId(OAUTH2_CLIENT_REGISTRATION_ID)
+                    .principal(new AnonymousAuthenticationToken("feignClient", "feignClient",
+                            AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")))
+                    .attribute(OAuth2AuthorizationContext.USERNAME_ATTRIBUTE_NAME, oAuth2Username)
+                    .attribute(OAuth2AuthorizationContext.PASSWORD_ATTRIBUTE_NAME, oAuth2Password)
+                    .build();
+        }
+
+        @Bean
+        public OAuth2FeignRequestInterceptor requestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager,
+                OAuth2AuthorizeRequest oAuth2AuthorizeRequest) {
+            return new OAuth2FeignRequestInterceptor(oAuth2AuthorizedClientManager, oAuth2AuthorizeRequest);
+        }
     }
 
-    @Bean
-    @ConditionalOnMissingBean
-    public OAuth2AuthorizedClientManager authorizedClientManager(final ClientRegistrationRepository clientRegistrationRepository,
-          final OAuth2AuthorizedClientService authorizedClientService) {
-      return new AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientService);
+    /**
+     * Configuration for external delegated authentication mechanism. This must be provided by the integrator of the SDK in the form of a bean that implements
+     * the interface {@link DelegatedAuthenticationRequestInterceptor}. This authentication method is enabled via the property
+     * <code>content.service.security.delegated</code>.
+     */
+    @Configuration
+    @ConditionalOnProperty("content.service.security.delegated")
+    protected static class DelegatedAuthenticationConfiguration {
+
+        @Bean
+        public DelegatedAuthenticationRequestInterceptor delegatedAuthenticationRequestInterceptor(DelegatedAuthenticationProvider
+                delegatedAuthenticationProvider) {
+            return new DelegatedAuthenticationRequestInterceptor(delegatedAuthenticationProvider);
+        }
     }
-
-    @Bean
-    public OAuth2FeignRequestInterceptor requestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager) {
-      return new OAuth2FeignRequestInterceptor(oAuth2AuthorizedClientManager,
-              OAuth2AuthorizeRequest.withClientRegistrationId("alfresco-rest-api")
-                      .principal(new AnonymousAuthenticationToken("feignClient", "feignClient", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")))
-                      .build());
-    }
-
-    public class OAuth2FeignRequestInterceptor implements RequestInterceptor {
-
-      private final OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager;
-      private final OAuth2AuthorizeRequest oAuth2AuthorizeRequest;
-
-      public OAuth2FeignRequestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager, OAuth2AuthorizeRequest oAuth2AuthorizeRequest) {
-        this.oAuth2AuthorizedClientManager = oAuth2AuthorizedClientManager;
-        this.oAuth2AuthorizeRequest = oAuth2AuthorizeRequest;
-      }
-
-      @Override
-      public void apply(RequestTemplate template) {
-        template.header(AUTHORIZATION,getAuthorizationToken());
-      }
-
-      private String getAuthorizationToken() {
-        final OAuth2AccessToken accessToken = oAuth2AuthorizedClientManager.authorize(oAuth2AuthorizeRequest).getAccessToken();
-        return String.format("%s %s", accessToken.getTokenType().getValue(), accessToken.getTokenValue());
-      }
-    }
-  }
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-core-rest-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-core-rest-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
@@ -15,33 +15,11 @@
  */
 package io.swagger.configuration;
 
-import feign.auth.BasicAuthRequestInterceptor;
-import java.util.ArrayList;
-import java.util.List;
-import org.alfresco.rest.sdk.feign.DelegatedAuthenticationProvider;
-import org.alfresco.rest.sdk.feign.DelegatedAuthenticationRequestInterceptor;
-import org.alfresco.rest.sdk.feign.oauth2.OAuth2FeignRequestInterceptor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
-import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientPropertiesRegistrationAdapter;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
+import org.alfresco.rest.sdk.feign.config.BasicAuthConfiguration;
+import org.alfresco.rest.sdk.feign.config.DelegatedAuthenticationConfiguration;
+import org.alfresco.rest.sdk.feign.config.OAuth2Configuration;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.authentication.AnonymousAuthenticationToken;
-import org.springframework.security.core.authority.AuthorityUtils;
-import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
-import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService;
-import org.springframework.security.oauth2.client.OAuth2AuthorizationContext;
-import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProvider;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
-import org.springframework.security.oauth2.client.registration.ClientRegistration;
-import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
-import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.context.annotation.Import;
 
 /**
  * Feign client Spring configuration that provides support for different authentication methods. Currently, supported methods are:
@@ -53,109 +31,7 @@ import org.springframework.security.oauth2.client.registration.InMemoryClientReg
  * </ul>
  */
 @Configuration
-@EnableConfigurationProperties({OAuth2ClientProperties.class})
+@Import({BasicAuthConfiguration.class, OAuth2Configuration.class, DelegatedAuthenticationConfiguration.class})
 public class ClientConfiguration {
 
-    /**
-     * Configuration for basic authentication. It configures a {@link BasicAuthRequestInterceptor} that uses the credentials configured in the properties
-     * <code>content.service.security.basicAuth.username</code> and <code>content.service.security.basicAuth.password</code>.
-     */
-    @Configuration
-    @ConditionalOnProperty("content.service.security.basicAuth.username")
-    protected static class BasicAuthConfiguration {
-
-        @Value("${content.service.security.basicAuth.username:#{null}}")
-        private String basicAuthUsername;
-        @Value("${content.service.security.basicAuth.password:#{null}}")
-        private String basicAuthPassword;
-
-        @Bean
-        @ConditionalOnProperty("content.service.security.basicAuth.username")
-        public BasicAuthRequestInterceptor basicAuthRequestInterceptor() {
-            return new BasicAuthRequestInterceptor(this.basicAuthUsername, this.basicAuthPassword);
-        }
-    }
-
-    /**
-     * Configuration for OAuth2 authentication flows. It configures a {@link OAuth2FeignRequestInterceptor} that retrieves the access token and generates the
-     * authorization header with the bearer. This is based in the OAuth2 support provided by the Spring Security module. So, the configuration must be done
-     * using the corresponding properties. The configuration of the client must be done using the properties
-     * <code>spring.security.oauth2.client.registration.alfresco-rest-api.xxxx</code>.
-     */
-    @Configuration
-    @ConditionalOnProperty("spring.security.oauth2.client.registration.alfresco-rest-api.provider")
-    protected static class OAuth2Configuration {
-
-        private static final String OAUTH2_CLIENT_REGISTRATION_ID = "alfresco-rest-api";
-
-        @Value("${spring.security.oauth2.client.registration.alfresco-rest-api.username:#{null}}")
-        private String oAuth2Username;
-        @Value("${spring.security.oauth2.client.registration.alfresco-rest-api.password:#{null}}")
-        private String oAuth2Password;
-
-        @Bean
-        @ConditionalOnMissingBean({ClientRegistrationRepository.class})
-        public InMemoryClientRegistrationRepository clientRegistrationRepository(OAuth2ClientProperties properties) {
-            List<ClientRegistration> registrations = new ArrayList(OAuth2ClientPropertiesRegistrationAdapter.getClientRegistrations(properties).values());
-            return new InMemoryClientRegistrationRepository(registrations);
-        }
-
-        @Bean
-        @ConditionalOnMissingBean({OAuth2AuthorizedClientService.class})
-        public InMemoryOAuth2AuthorizedClientService authorizedClientService(ClientRegistrationRepository clientRegistrationRepository) {
-            return new InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository);
-        }
-
-        @Bean
-        @ConditionalOnMissingBean
-        public OAuth2AuthorizedClientProvider oAuth2AuthorizedClientProvider() {
-            return OAuth2AuthorizedClientProviderBuilder.builder()
-                    .clientCredentials()
-                    .password()
-                    .build();
-        }
-
-        @Bean
-        @ConditionalOnMissingBean
-        public OAuth2AuthorizedClientManager authorizedClientManager(final ClientRegistrationRepository clientRegistrationRepository,
-                final OAuth2AuthorizedClientService authorizedClientService, OAuth2AuthorizedClientProvider oAuth2AuthorizedClientProvider) {
-            AuthorizedClientServiceOAuth2AuthorizedClientManager authorizedClientServiceOAuth2AuthorizedClientManager =
-                    new AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientService);
-            authorizedClientServiceOAuth2AuthorizedClientManager.setAuthorizedClientProvider(oAuth2AuthorizedClientProvider);
-            authorizedClientServiceOAuth2AuthorizedClientManager.setContextAttributesMapper(OAuth2AuthorizeRequest::getAttributes);
-            return authorizedClientServiceOAuth2AuthorizedClientManager;
-        }
-
-        @Bean
-        public OAuth2AuthorizeRequest oAuth2AuthorizeRequest() {
-            return OAuth2AuthorizeRequest.withClientRegistrationId(OAUTH2_CLIENT_REGISTRATION_ID)
-                    .principal(new AnonymousAuthenticationToken("feignClient", "feignClient",
-                            AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")))
-                    .attribute(OAuth2AuthorizationContext.USERNAME_ATTRIBUTE_NAME, oAuth2Username)
-                    .attribute(OAuth2AuthorizationContext.PASSWORD_ATTRIBUTE_NAME, oAuth2Password)
-                    .build();
-        }
-
-        @Bean
-        public OAuth2FeignRequestInterceptor requestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager,
-                OAuth2AuthorizeRequest oAuth2AuthorizeRequest) {
-            return new OAuth2FeignRequestInterceptor(oAuth2AuthorizedClientManager, oAuth2AuthorizeRequest);
-        }
-    }
-
-    /**
-     * Configuration for external delegated authentication mechanism. This must be provided by the integrator of the SDK in the form of a bean that implements
-     * the interface {@link DelegatedAuthenticationRequestInterceptor}. This authentication method is enabled via the property
-     * <code>content.service.security.delegated</code>.
-     */
-    @Configuration
-    @ConditionalOnProperty("content.service.security.delegated")
-    protected static class DelegatedAuthenticationConfiguration {
-
-        @Bean
-        public DelegatedAuthenticationRequestInterceptor delegatedAuthenticationRequestInterceptor(DelegatedAuthenticationProvider
-                delegatedAuthenticationProvider) {
-            return new DelegatedAuthenticationRequestInterceptor(delegatedAuthenticationProvider);
-        }
-    }
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-search-rest-api/pom.xml
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-search-rest-api/pom.xml
@@ -25,6 +25,10 @@
       <artifactId>spring-boot-starter-oauth2-client</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.alfresco</groupId>
+      <artifactId>alfresco-java-rest-api-common</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
     </dependency>

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-search-rest-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-search-rest-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
@@ -15,29 +15,104 @@
  */
 package io.swagger.configuration;
 
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
 import feign.auth.BasicAuthRequestInterceptor;
+import java.util.ArrayList;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientPropertiesRegistrationAdapter;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
 
 @Configuration
-@EnableConfigurationProperties
+@EnableConfigurationProperties({OAuth2ClientProperties.class})
 public class ClientConfiguration {
 
-  @Value("${content.service.security.basicAuth.username}")
-  private String basicAuthUsername;
+  @Configuration
+  @ConditionalOnProperty("content.service.security.basicAuth.username")
+  protected static class BasicAuthConfiguration {
 
-  @Value("${content.service.security.basicAuth.password}")
-  private String basicAuthPassword;
+    @Value("${content.service.security.basicAuth.username:#{null}}")
+    private String basicAuthUsername;
+    @Value("${content.service.security.basicAuth.password:#{null}}")
+    private String basicAuthPassword;
 
-  @Bean
-  @ConditionalOnProperty(name = "content.service.security.basicAuth.username")
-  public BasicAuthRequestInterceptor basicAuthRequestInterceptor() {
-    return new BasicAuthRequestInterceptor(this.basicAuthUsername, this.basicAuthPassword);
+    @Bean
+    @ConditionalOnProperty("content.service.security.basicAuth.username")
+    public BasicAuthRequestInterceptor basicAuthRequestInterceptor() {
+      return new BasicAuthRequestInterceptor(this.basicAuthUsername, this.basicAuthPassword);
+    }
   }
 
+  @Configuration
+  @ConditionalOnProperty("spring.security.oauth2.client.registration.alfresco-rest-api.provider")
+  protected static class OAuth2Configuration {
+
+    @Bean
+    @ConditionalOnMissingBean({ClientRegistrationRepository.class})
+    public InMemoryClientRegistrationRepository clientRegistrationRepository(OAuth2ClientProperties properties) {
+      List<ClientRegistration> registrations = new ArrayList(OAuth2ClientPropertiesRegistrationAdapter.getClientRegistrations(properties).values());
+      return new InMemoryClientRegistrationRepository(registrations);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean({OAuth2AuthorizedClientService.class})
+    public InMemoryOAuth2AuthorizedClientService authorizedClientService(ClientRegistrationRepository clientRegistrationRepository) {
+      return new InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public OAuth2AuthorizedClientManager authorizedClientManager(final ClientRegistrationRepository clientRegistrationRepository,
+          final OAuth2AuthorizedClientService authorizedClientService) {
+      return new AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientService);
+    }
+
+    @Bean
+    public OAuth2FeignRequestInterceptor requestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager) {
+      return new OAuth2FeignRequestInterceptor(oAuth2AuthorizedClientManager,
+              OAuth2AuthorizeRequest.withClientRegistrationId("alfresco-rest-api")
+                      .principal(new AnonymousAuthenticationToken("feignClient", "feignClient", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")))
+                      .build());
+    }
+
+    public class OAuth2FeignRequestInterceptor implements RequestInterceptor {
+
+      private final OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager;
+      private final OAuth2AuthorizeRequest oAuth2AuthorizeRequest;
+
+      public OAuth2FeignRequestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager, OAuth2AuthorizeRequest oAuth2AuthorizeRequest) {
+        this.oAuth2AuthorizedClientManager = oAuth2AuthorizedClientManager;
+        this.oAuth2AuthorizeRequest = oAuth2AuthorizeRequest;
+      }
+
+      @Override
+      public void apply(RequestTemplate template) {
+        template.header(AUTHORIZATION,getAuthorizationToken());
+      }
+
+      private String getAuthorizationToken() {
+        final OAuth2AccessToken accessToken = oAuth2AuthorizedClientManager.authorize(oAuth2AuthorizeRequest).getAccessToken();
+        return String.format("%s %s", accessToken.getTokenType().getValue(), accessToken.getTokenValue());
+      }
+    }
+  }
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-search-rest-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-search-rest-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
@@ -15,13 +15,12 @@
  */
 package io.swagger.configuration;
 
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-
-import feign.RequestInterceptor;
-import feign.RequestTemplate;
 import feign.auth.BasicAuthRequestInterceptor;
 import java.util.ArrayList;
 import java.util.List;
+import org.alfresco.rest.sdk.feign.DelegatedAuthenticationProvider;
+import org.alfresco.rest.sdk.feign.DelegatedAuthenticationRequestInterceptor;
+import org.alfresco.rest.sdk.feign.oauth2.OAuth2FeignRequestInterceptor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -34,85 +33,129 @@ import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.OAuth2AuthorizationContext;
 import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProvider;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
-import org.springframework.security.oauth2.core.OAuth2AccessToken;
 
+/**
+ * Feign client Spring configuration that provides support for different authentication methods. Currently, supported methods are:
+ * <ul>
+ *     <li>Basic Authentication</li>
+ *     <li>OAuth2 - Client credentials flow</li>
+ *     <li>OAuth2 - Password flow</li>
+ *     <li>Delegated (external) authentication</li>
+ * </ul>
+ */
 @Configuration
 @EnableConfigurationProperties({OAuth2ClientProperties.class})
 public class ClientConfiguration {
 
-  @Configuration
-  @ConditionalOnProperty("content.service.security.basicAuth.username")
-  protected static class BasicAuthConfiguration {
-
-    @Value("${content.service.security.basicAuth.username:#{null}}")
-    private String basicAuthUsername;
-    @Value("${content.service.security.basicAuth.password:#{null}}")
-    private String basicAuthPassword;
-
-    @Bean
+    /**
+     * Configuration for basic authentication. It configures a {@link BasicAuthRequestInterceptor} that uses the credentials configured in the properties
+     * <code>content.service.security.basicAuth.username</code> and <code>content.service.security.basicAuth.password</code>.
+     */
+    @Configuration
     @ConditionalOnProperty("content.service.security.basicAuth.username")
-    public BasicAuthRequestInterceptor basicAuthRequestInterceptor() {
-      return new BasicAuthRequestInterceptor(this.basicAuthUsername, this.basicAuthPassword);
-    }
-  }
+    protected static class BasicAuthConfiguration {
 
-  @Configuration
-  @ConditionalOnProperty("spring.security.oauth2.client.registration.alfresco-rest-api.provider")
-  protected static class OAuth2Configuration {
+        @Value("${content.service.security.basicAuth.username:#{null}}")
+        private String basicAuthUsername;
+        @Value("${content.service.security.basicAuth.password:#{null}}")
+        private String basicAuthPassword;
 
-    @Bean
-    @ConditionalOnMissingBean({ClientRegistrationRepository.class})
-    public InMemoryClientRegistrationRepository clientRegistrationRepository(OAuth2ClientProperties properties) {
-      List<ClientRegistration> registrations = new ArrayList(OAuth2ClientPropertiesRegistrationAdapter.getClientRegistrations(properties).values());
-      return new InMemoryClientRegistrationRepository(registrations);
+        @Bean
+        @ConditionalOnProperty("content.service.security.basicAuth.username")
+        public BasicAuthRequestInterceptor basicAuthRequestInterceptor() {
+            return new BasicAuthRequestInterceptor(this.basicAuthUsername, this.basicAuthPassword);
+        }
     }
 
-    @Bean
-    @ConditionalOnMissingBean({OAuth2AuthorizedClientService.class})
-    public InMemoryOAuth2AuthorizedClientService authorizedClientService(ClientRegistrationRepository clientRegistrationRepository) {
-      return new InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository);
+    /**
+     * Configuration for OAuth2 authentication flows. It configures a {@link OAuth2FeignRequestInterceptor} that retrieves the access token and generates the
+     * authorization header with the bearer. This is based in the OAuth2 support provided by the Spring Security module. So, the configuration must be done
+     * using the corresponding properties. The configuration of the client must be done using the properties
+     * <code>spring.security.oauth2.client.registration.alfresco-rest-api.xxxx</code>.
+     */
+    @Configuration
+    @ConditionalOnProperty("spring.security.oauth2.client.registration.alfresco-rest-api.provider")
+    protected static class OAuth2Configuration {
+
+        private static final String OAUTH2_CLIENT_REGISTRATION_ID = "alfresco-rest-api";
+
+        @Value("${spring.security.oauth2.client.registration.alfresco-rest-api.username:#{null}}")
+        private String oAuth2Username;
+        @Value("${spring.security.oauth2.client.registration.alfresco-rest-api.password:#{null}}")
+        private String oAuth2Password;
+
+        @Bean
+        @ConditionalOnMissingBean({ClientRegistrationRepository.class})
+        public InMemoryClientRegistrationRepository clientRegistrationRepository(OAuth2ClientProperties properties) {
+            List<ClientRegistration> registrations = new ArrayList(OAuth2ClientPropertiesRegistrationAdapter.getClientRegistrations(properties).values());
+            return new InMemoryClientRegistrationRepository(registrations);
+        }
+
+        @Bean
+        @ConditionalOnMissingBean({OAuth2AuthorizedClientService.class})
+        public InMemoryOAuth2AuthorizedClientService authorizedClientService(ClientRegistrationRepository clientRegistrationRepository) {
+            return new InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository);
+        }
+
+        @Bean
+        @ConditionalOnMissingBean
+        public OAuth2AuthorizedClientProvider oAuth2AuthorizedClientProvider() {
+            return OAuth2AuthorizedClientProviderBuilder.builder()
+                    .clientCredentials()
+                    .password()
+                    .build();
+        }
+
+        @Bean
+        @ConditionalOnMissingBean
+        public OAuth2AuthorizedClientManager authorizedClientManager(final ClientRegistrationRepository clientRegistrationRepository,
+                final OAuth2AuthorizedClientService authorizedClientService, OAuth2AuthorizedClientProvider oAuth2AuthorizedClientProvider) {
+            AuthorizedClientServiceOAuth2AuthorizedClientManager authorizedClientServiceOAuth2AuthorizedClientManager =
+                    new AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientService);
+            authorizedClientServiceOAuth2AuthorizedClientManager.setAuthorizedClientProvider(oAuth2AuthorizedClientProvider);
+            authorizedClientServiceOAuth2AuthorizedClientManager.setContextAttributesMapper(OAuth2AuthorizeRequest::getAttributes);
+            return authorizedClientServiceOAuth2AuthorizedClientManager;
+        }
+
+        @Bean
+        public OAuth2AuthorizeRequest oAuth2AuthorizeRequest() {
+            return OAuth2AuthorizeRequest.withClientRegistrationId(OAUTH2_CLIENT_REGISTRATION_ID)
+                    .principal(new AnonymousAuthenticationToken("feignClient", "feignClient",
+                            AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")))
+                    .attribute(OAuth2AuthorizationContext.USERNAME_ATTRIBUTE_NAME, oAuth2Username)
+                    .attribute(OAuth2AuthorizationContext.PASSWORD_ATTRIBUTE_NAME, oAuth2Password)
+                    .build();
+        }
+
+        @Bean
+        public OAuth2FeignRequestInterceptor requestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager,
+                OAuth2AuthorizeRequest oAuth2AuthorizeRequest) {
+            return new OAuth2FeignRequestInterceptor(oAuth2AuthorizedClientManager, oAuth2AuthorizeRequest);
+        }
     }
 
-    @Bean
-    @ConditionalOnMissingBean
-    public OAuth2AuthorizedClientManager authorizedClientManager(final ClientRegistrationRepository clientRegistrationRepository,
-          final OAuth2AuthorizedClientService authorizedClientService) {
-      return new AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientService);
+    /**
+     * Configuration for external delegated authentication mechanism. This must be provided by the integrator of the SDK in the form of a bean that implements
+     * the interface {@link DelegatedAuthenticationRequestInterceptor}. This authentication method is enabled via the property
+     * <code>content.service.security.delegated</code>.
+     */
+    @Configuration
+    @ConditionalOnProperty("content.service.security.delegated")
+    protected static class DelegatedAuthenticationConfiguration {
+
+        @Bean
+        public DelegatedAuthenticationRequestInterceptor delegatedAuthenticationRequestInterceptor(DelegatedAuthenticationProvider
+                delegatedAuthenticationProvider) {
+            return new DelegatedAuthenticationRequestInterceptor(delegatedAuthenticationProvider);
+        }
     }
-
-    @Bean
-    public OAuth2FeignRequestInterceptor requestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager) {
-      return new OAuth2FeignRequestInterceptor(oAuth2AuthorizedClientManager,
-              OAuth2AuthorizeRequest.withClientRegistrationId("alfresco-rest-api")
-                      .principal(new AnonymousAuthenticationToken("feignClient", "feignClient", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")))
-                      .build());
-    }
-
-    public class OAuth2FeignRequestInterceptor implements RequestInterceptor {
-
-      private final OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager;
-      private final OAuth2AuthorizeRequest oAuth2AuthorizeRequest;
-
-      public OAuth2FeignRequestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager, OAuth2AuthorizeRequest oAuth2AuthorizeRequest) {
-        this.oAuth2AuthorizedClientManager = oAuth2AuthorizedClientManager;
-        this.oAuth2AuthorizeRequest = oAuth2AuthorizeRequest;
-      }
-
-      @Override
-      public void apply(RequestTemplate template) {
-        template.header(AUTHORIZATION,getAuthorizationToken());
-      }
-
-      private String getAuthorizationToken() {
-        final OAuth2AccessToken accessToken = oAuth2AuthorizedClientManager.authorize(oAuth2AuthorizeRequest).getAccessToken();
-        return String.format("%s %s", accessToken.getTokenType().getValue(), accessToken.getTokenValue());
-      }
-    }
-  }
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-search-rest-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-search-rest-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
@@ -15,33 +15,11 @@
  */
 package io.swagger.configuration;
 
-import feign.auth.BasicAuthRequestInterceptor;
-import java.util.ArrayList;
-import java.util.List;
-import org.alfresco.rest.sdk.feign.DelegatedAuthenticationProvider;
-import org.alfresco.rest.sdk.feign.DelegatedAuthenticationRequestInterceptor;
-import org.alfresco.rest.sdk.feign.oauth2.OAuth2FeignRequestInterceptor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
-import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientPropertiesRegistrationAdapter;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
+import org.alfresco.rest.sdk.feign.config.BasicAuthConfiguration;
+import org.alfresco.rest.sdk.feign.config.DelegatedAuthenticationConfiguration;
+import org.alfresco.rest.sdk.feign.config.OAuth2Configuration;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.authentication.AnonymousAuthenticationToken;
-import org.springframework.security.core.authority.AuthorityUtils;
-import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
-import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService;
-import org.springframework.security.oauth2.client.OAuth2AuthorizationContext;
-import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProvider;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
-import org.springframework.security.oauth2.client.registration.ClientRegistration;
-import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
-import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.context.annotation.Import;
 
 /**
  * Feign client Spring configuration that provides support for different authentication methods. Currently, supported methods are:
@@ -53,109 +31,7 @@ import org.springframework.security.oauth2.client.registration.InMemoryClientReg
  * </ul>
  */
 @Configuration
-@EnableConfigurationProperties({OAuth2ClientProperties.class})
+@Import({BasicAuthConfiguration.class, OAuth2Configuration.class, DelegatedAuthenticationConfiguration.class})
 public class ClientConfiguration {
 
-    /**
-     * Configuration for basic authentication. It configures a {@link BasicAuthRequestInterceptor} that uses the credentials configured in the properties
-     * <code>content.service.security.basicAuth.username</code> and <code>content.service.security.basicAuth.password</code>.
-     */
-    @Configuration
-    @ConditionalOnProperty("content.service.security.basicAuth.username")
-    protected static class BasicAuthConfiguration {
-
-        @Value("${content.service.security.basicAuth.username:#{null}}")
-        private String basicAuthUsername;
-        @Value("${content.service.security.basicAuth.password:#{null}}")
-        private String basicAuthPassword;
-
-        @Bean
-        @ConditionalOnProperty("content.service.security.basicAuth.username")
-        public BasicAuthRequestInterceptor basicAuthRequestInterceptor() {
-            return new BasicAuthRequestInterceptor(this.basicAuthUsername, this.basicAuthPassword);
-        }
-    }
-
-    /**
-     * Configuration for OAuth2 authentication flows. It configures a {@link OAuth2FeignRequestInterceptor} that retrieves the access token and generates the
-     * authorization header with the bearer. This is based in the OAuth2 support provided by the Spring Security module. So, the configuration must be done
-     * using the corresponding properties. The configuration of the client must be done using the properties
-     * <code>spring.security.oauth2.client.registration.alfresco-rest-api.xxxx</code>.
-     */
-    @Configuration
-    @ConditionalOnProperty("spring.security.oauth2.client.registration.alfresco-rest-api.provider")
-    protected static class OAuth2Configuration {
-
-        private static final String OAUTH2_CLIENT_REGISTRATION_ID = "alfresco-rest-api";
-
-        @Value("${spring.security.oauth2.client.registration.alfresco-rest-api.username:#{null}}")
-        private String oAuth2Username;
-        @Value("${spring.security.oauth2.client.registration.alfresco-rest-api.password:#{null}}")
-        private String oAuth2Password;
-
-        @Bean
-        @ConditionalOnMissingBean({ClientRegistrationRepository.class})
-        public InMemoryClientRegistrationRepository clientRegistrationRepository(OAuth2ClientProperties properties) {
-            List<ClientRegistration> registrations = new ArrayList(OAuth2ClientPropertiesRegistrationAdapter.getClientRegistrations(properties).values());
-            return new InMemoryClientRegistrationRepository(registrations);
-        }
-
-        @Bean
-        @ConditionalOnMissingBean({OAuth2AuthorizedClientService.class})
-        public InMemoryOAuth2AuthorizedClientService authorizedClientService(ClientRegistrationRepository clientRegistrationRepository) {
-            return new InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository);
-        }
-
-        @Bean
-        @ConditionalOnMissingBean
-        public OAuth2AuthorizedClientProvider oAuth2AuthorizedClientProvider() {
-            return OAuth2AuthorizedClientProviderBuilder.builder()
-                    .clientCredentials()
-                    .password()
-                    .build();
-        }
-
-        @Bean
-        @ConditionalOnMissingBean
-        public OAuth2AuthorizedClientManager authorizedClientManager(final ClientRegistrationRepository clientRegistrationRepository,
-                final OAuth2AuthorizedClientService authorizedClientService, OAuth2AuthorizedClientProvider oAuth2AuthorizedClientProvider) {
-            AuthorizedClientServiceOAuth2AuthorizedClientManager authorizedClientServiceOAuth2AuthorizedClientManager =
-                    new AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientService);
-            authorizedClientServiceOAuth2AuthorizedClientManager.setAuthorizedClientProvider(oAuth2AuthorizedClientProvider);
-            authorizedClientServiceOAuth2AuthorizedClientManager.setContextAttributesMapper(OAuth2AuthorizeRequest::getAttributes);
-            return authorizedClientServiceOAuth2AuthorizedClientManager;
-        }
-
-        @Bean
-        public OAuth2AuthorizeRequest oAuth2AuthorizeRequest() {
-            return OAuth2AuthorizeRequest.withClientRegistrationId(OAUTH2_CLIENT_REGISTRATION_ID)
-                    .principal(new AnonymousAuthenticationToken("feignClient", "feignClient",
-                            AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")))
-                    .attribute(OAuth2AuthorizationContext.USERNAME_ATTRIBUTE_NAME, oAuth2Username)
-                    .attribute(OAuth2AuthorizationContext.PASSWORD_ATTRIBUTE_NAME, oAuth2Password)
-                    .build();
-        }
-
-        @Bean
-        public OAuth2FeignRequestInterceptor requestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager,
-                OAuth2AuthorizeRequest oAuth2AuthorizeRequest) {
-            return new OAuth2FeignRequestInterceptor(oAuth2AuthorizedClientManager, oAuth2AuthorizeRequest);
-        }
-    }
-
-    /**
-     * Configuration for external delegated authentication mechanism. This must be provided by the integrator of the SDK in the form of a bean that implements
-     * the interface {@link DelegatedAuthenticationRequestInterceptor}. This authentication method is enabled via the property
-     * <code>content.service.security.delegated</code>.
-     */
-    @Configuration
-    @ConditionalOnProperty("content.service.security.delegated")
-    protected static class DelegatedAuthenticationConfiguration {
-
-        @Bean
-        public DelegatedAuthenticationRequestInterceptor delegatedAuthenticationRequestInterceptor(DelegatedAuthenticationProvider
-                delegatedAuthenticationProvider) {
-            return new DelegatedAuthenticationRequestInterceptor(delegatedAuthenticationProvider);
-        }
-    }
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-search-sql-rest-api/pom.xml
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-search-sql-rest-api/pom.xml
@@ -25,6 +25,10 @@
       <artifactId>spring-boot-starter-oauth2-client</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.alfresco</groupId>
+      <artifactId>alfresco-java-rest-api-common</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
     </dependency>

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-search-sql-rest-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-search-sql-rest-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
@@ -15,29 +15,104 @@
  */
 package io.swagger.configuration;
 
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
 import feign.auth.BasicAuthRequestInterceptor;
+import java.util.ArrayList;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientPropertiesRegistrationAdapter;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
 
 @Configuration
-@EnableConfigurationProperties
+@EnableConfigurationProperties({OAuth2ClientProperties.class})
 public class ClientConfiguration {
 
-  @Value("${content.service.security.basicAuth.username}")
-  private String basicAuthUsername;
+  @Configuration
+  @ConditionalOnProperty("content.service.security.basicAuth.username")
+  protected static class BasicAuthConfiguration {
 
-  @Value("${content.service.security.basicAuth.password}")
-  private String basicAuthPassword;
+    @Value("${content.service.security.basicAuth.username:#{null}}")
+    private String basicAuthUsername;
+    @Value("${content.service.security.basicAuth.password:#{null}}")
+    private String basicAuthPassword;
 
-  @Bean
-  @ConditionalOnProperty(name = "content.service.security.basicAuth.username")
-  public BasicAuthRequestInterceptor basicAuthRequestInterceptor() {
-    return new BasicAuthRequestInterceptor(this.basicAuthUsername, this.basicAuthPassword);
+    @Bean
+    @ConditionalOnProperty("content.service.security.basicAuth.username")
+    public BasicAuthRequestInterceptor basicAuthRequestInterceptor() {
+      return new BasicAuthRequestInterceptor(this.basicAuthUsername, this.basicAuthPassword);
+    }
   }
 
+  @Configuration
+  @ConditionalOnProperty("spring.security.oauth2.client.registration.alfresco-rest-api.provider")
+  protected static class OAuth2Configuration {
+
+    @Bean
+    @ConditionalOnMissingBean({ClientRegistrationRepository.class})
+    public InMemoryClientRegistrationRepository clientRegistrationRepository(OAuth2ClientProperties properties) {
+      List<ClientRegistration> registrations = new ArrayList(OAuth2ClientPropertiesRegistrationAdapter.getClientRegistrations(properties).values());
+      return new InMemoryClientRegistrationRepository(registrations);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean({OAuth2AuthorizedClientService.class})
+    public InMemoryOAuth2AuthorizedClientService authorizedClientService(ClientRegistrationRepository clientRegistrationRepository) {
+      return new InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public OAuth2AuthorizedClientManager authorizedClientManager(final ClientRegistrationRepository clientRegistrationRepository,
+          final OAuth2AuthorizedClientService authorizedClientService) {
+      return new AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientService);
+    }
+
+    @Bean
+    public OAuth2FeignRequestInterceptor requestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager) {
+      return new OAuth2FeignRequestInterceptor(oAuth2AuthorizedClientManager,
+              OAuth2AuthorizeRequest.withClientRegistrationId("alfresco-rest-api")
+                      .principal(new AnonymousAuthenticationToken("feignClient", "feignClient", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")))
+                      .build());
+    }
+
+    public class OAuth2FeignRequestInterceptor implements RequestInterceptor {
+
+      private final OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager;
+      private final OAuth2AuthorizeRequest oAuth2AuthorizeRequest;
+
+      public OAuth2FeignRequestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager, OAuth2AuthorizeRequest oAuth2AuthorizeRequest) {
+        this.oAuth2AuthorizedClientManager = oAuth2AuthorizedClientManager;
+        this.oAuth2AuthorizeRequest = oAuth2AuthorizeRequest;
+      }
+
+      @Override
+      public void apply(RequestTemplate template) {
+        template.header(AUTHORIZATION,getAuthorizationToken());
+      }
+
+      private String getAuthorizationToken() {
+        final OAuth2AccessToken accessToken = oAuth2AuthorizedClientManager.authorize(oAuth2AuthorizeRequest).getAccessToken();
+        return String.format("%s %s", accessToken.getTokenType().getValue(), accessToken.getTokenValue());
+      }
+    }
+  }
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-search-sql-rest-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-search-sql-rest-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
@@ -15,13 +15,12 @@
  */
 package io.swagger.configuration;
 
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-
-import feign.RequestInterceptor;
-import feign.RequestTemplate;
 import feign.auth.BasicAuthRequestInterceptor;
 import java.util.ArrayList;
 import java.util.List;
+import org.alfresco.rest.sdk.feign.DelegatedAuthenticationProvider;
+import org.alfresco.rest.sdk.feign.DelegatedAuthenticationRequestInterceptor;
+import org.alfresco.rest.sdk.feign.oauth2.OAuth2FeignRequestInterceptor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -34,85 +33,129 @@ import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.OAuth2AuthorizationContext;
 import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProvider;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
-import org.springframework.security.oauth2.core.OAuth2AccessToken;
 
+/**
+ * Feign client Spring configuration that provides support for different authentication methods. Currently, supported methods are:
+ * <ul>
+ *     <li>Basic Authentication</li>
+ *     <li>OAuth2 - Client credentials flow</li>
+ *     <li>OAuth2 - Password flow</li>
+ *     <li>Delegated (external) authentication</li>
+ * </ul>
+ */
 @Configuration
 @EnableConfigurationProperties({OAuth2ClientProperties.class})
 public class ClientConfiguration {
 
-  @Configuration
-  @ConditionalOnProperty("content.service.security.basicAuth.username")
-  protected static class BasicAuthConfiguration {
-
-    @Value("${content.service.security.basicAuth.username:#{null}}")
-    private String basicAuthUsername;
-    @Value("${content.service.security.basicAuth.password:#{null}}")
-    private String basicAuthPassword;
-
-    @Bean
+    /**
+     * Configuration for basic authentication. It configures a {@link BasicAuthRequestInterceptor} that uses the credentials configured in the properties
+     * <code>content.service.security.basicAuth.username</code> and <code>content.service.security.basicAuth.password</code>.
+     */
+    @Configuration
     @ConditionalOnProperty("content.service.security.basicAuth.username")
-    public BasicAuthRequestInterceptor basicAuthRequestInterceptor() {
-      return new BasicAuthRequestInterceptor(this.basicAuthUsername, this.basicAuthPassword);
-    }
-  }
+    protected static class BasicAuthConfiguration {
 
-  @Configuration
-  @ConditionalOnProperty("spring.security.oauth2.client.registration.alfresco-rest-api.provider")
-  protected static class OAuth2Configuration {
+        @Value("${content.service.security.basicAuth.username:#{null}}")
+        private String basicAuthUsername;
+        @Value("${content.service.security.basicAuth.password:#{null}}")
+        private String basicAuthPassword;
 
-    @Bean
-    @ConditionalOnMissingBean({ClientRegistrationRepository.class})
-    public InMemoryClientRegistrationRepository clientRegistrationRepository(OAuth2ClientProperties properties) {
-      List<ClientRegistration> registrations = new ArrayList(OAuth2ClientPropertiesRegistrationAdapter.getClientRegistrations(properties).values());
-      return new InMemoryClientRegistrationRepository(registrations);
+        @Bean
+        @ConditionalOnProperty("content.service.security.basicAuth.username")
+        public BasicAuthRequestInterceptor basicAuthRequestInterceptor() {
+            return new BasicAuthRequestInterceptor(this.basicAuthUsername, this.basicAuthPassword);
+        }
     }
 
-    @Bean
-    @ConditionalOnMissingBean({OAuth2AuthorizedClientService.class})
-    public InMemoryOAuth2AuthorizedClientService authorizedClientService(ClientRegistrationRepository clientRegistrationRepository) {
-      return new InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository);
+    /**
+     * Configuration for OAuth2 authentication flows. It configures a {@link OAuth2FeignRequestInterceptor} that retrieves the access token and generates the
+     * authorization header with the bearer. This is based in the OAuth2 support provided by the Spring Security module. So, the configuration must be done
+     * using the corresponding properties. The configuration of the client must be done using the properties
+     * <code>spring.security.oauth2.client.registration.alfresco-rest-api.xxxx</code>.
+     */
+    @Configuration
+    @ConditionalOnProperty("spring.security.oauth2.client.registration.alfresco-rest-api.provider")
+    protected static class OAuth2Configuration {
+
+        private static final String OAUTH2_CLIENT_REGISTRATION_ID = "alfresco-rest-api";
+
+        @Value("${spring.security.oauth2.client.registration.alfresco-rest-api.username:#{null}}")
+        private String oAuth2Username;
+        @Value("${spring.security.oauth2.client.registration.alfresco-rest-api.password:#{null}}")
+        private String oAuth2Password;
+
+        @Bean
+        @ConditionalOnMissingBean({ClientRegistrationRepository.class})
+        public InMemoryClientRegistrationRepository clientRegistrationRepository(OAuth2ClientProperties properties) {
+            List<ClientRegistration> registrations = new ArrayList(OAuth2ClientPropertiesRegistrationAdapter.getClientRegistrations(properties).values());
+            return new InMemoryClientRegistrationRepository(registrations);
+        }
+
+        @Bean
+        @ConditionalOnMissingBean({OAuth2AuthorizedClientService.class})
+        public InMemoryOAuth2AuthorizedClientService authorizedClientService(ClientRegistrationRepository clientRegistrationRepository) {
+            return new InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository);
+        }
+
+        @Bean
+        @ConditionalOnMissingBean
+        public OAuth2AuthorizedClientProvider oAuth2AuthorizedClientProvider() {
+            return OAuth2AuthorizedClientProviderBuilder.builder()
+                    .clientCredentials()
+                    .password()
+                    .build();
+        }
+
+        @Bean
+        @ConditionalOnMissingBean
+        public OAuth2AuthorizedClientManager authorizedClientManager(final ClientRegistrationRepository clientRegistrationRepository,
+                final OAuth2AuthorizedClientService authorizedClientService, OAuth2AuthorizedClientProvider oAuth2AuthorizedClientProvider) {
+            AuthorizedClientServiceOAuth2AuthorizedClientManager authorizedClientServiceOAuth2AuthorizedClientManager =
+                    new AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientService);
+            authorizedClientServiceOAuth2AuthorizedClientManager.setAuthorizedClientProvider(oAuth2AuthorizedClientProvider);
+            authorizedClientServiceOAuth2AuthorizedClientManager.setContextAttributesMapper(OAuth2AuthorizeRequest::getAttributes);
+            return authorizedClientServiceOAuth2AuthorizedClientManager;
+        }
+
+        @Bean
+        public OAuth2AuthorizeRequest oAuth2AuthorizeRequest() {
+            return OAuth2AuthorizeRequest.withClientRegistrationId(OAUTH2_CLIENT_REGISTRATION_ID)
+                    .principal(new AnonymousAuthenticationToken("feignClient", "feignClient",
+                            AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")))
+                    .attribute(OAuth2AuthorizationContext.USERNAME_ATTRIBUTE_NAME, oAuth2Username)
+                    .attribute(OAuth2AuthorizationContext.PASSWORD_ATTRIBUTE_NAME, oAuth2Password)
+                    .build();
+        }
+
+        @Bean
+        public OAuth2FeignRequestInterceptor requestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager,
+                OAuth2AuthorizeRequest oAuth2AuthorizeRequest) {
+            return new OAuth2FeignRequestInterceptor(oAuth2AuthorizedClientManager, oAuth2AuthorizeRequest);
+        }
     }
 
-    @Bean
-    @ConditionalOnMissingBean
-    public OAuth2AuthorizedClientManager authorizedClientManager(final ClientRegistrationRepository clientRegistrationRepository,
-          final OAuth2AuthorizedClientService authorizedClientService) {
-      return new AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientService);
+    /**
+     * Configuration for external delegated authentication mechanism. This must be provided by the integrator of the SDK in the form of a bean that implements
+     * the interface {@link DelegatedAuthenticationRequestInterceptor}. This authentication method is enabled via the property
+     * <code>content.service.security.delegated</code>.
+     */
+    @Configuration
+    @ConditionalOnProperty("content.service.security.delegated")
+    protected static class DelegatedAuthenticationConfiguration {
+
+        @Bean
+        public DelegatedAuthenticationRequestInterceptor delegatedAuthenticationRequestInterceptor(DelegatedAuthenticationProvider
+                delegatedAuthenticationProvider) {
+            return new DelegatedAuthenticationRequestInterceptor(delegatedAuthenticationProvider);
+        }
     }
-
-    @Bean
-    public OAuth2FeignRequestInterceptor requestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager) {
-      return new OAuth2FeignRequestInterceptor(oAuth2AuthorizedClientManager,
-              OAuth2AuthorizeRequest.withClientRegistrationId("alfresco-rest-api")
-                      .principal(new AnonymousAuthenticationToken("feignClient", "feignClient", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")))
-                      .build());
-    }
-
-    public class OAuth2FeignRequestInterceptor implements RequestInterceptor {
-
-      private final OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager;
-      private final OAuth2AuthorizeRequest oAuth2AuthorizeRequest;
-
-      public OAuth2FeignRequestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager, OAuth2AuthorizeRequest oAuth2AuthorizeRequest) {
-        this.oAuth2AuthorizedClientManager = oAuth2AuthorizedClientManager;
-        this.oAuth2AuthorizeRequest = oAuth2AuthorizeRequest;
-      }
-
-      @Override
-      public void apply(RequestTemplate template) {
-        template.header(AUTHORIZATION,getAuthorizationToken());
-      }
-
-      private String getAuthorizationToken() {
-        final OAuth2AccessToken accessToken = oAuth2AuthorizedClientManager.authorize(oAuth2AuthorizeRequest).getAccessToken();
-        return String.format("%s %s", accessToken.getTokenType().getValue(), accessToken.getTokenValue());
-      }
-    }
-  }
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-search-sql-rest-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-search-sql-rest-api/src/main/java/io/swagger/configuration/ClientConfiguration.java
@@ -15,33 +15,11 @@
  */
 package io.swagger.configuration;
 
-import feign.auth.BasicAuthRequestInterceptor;
-import java.util.ArrayList;
-import java.util.List;
-import org.alfresco.rest.sdk.feign.DelegatedAuthenticationProvider;
-import org.alfresco.rest.sdk.feign.DelegatedAuthenticationRequestInterceptor;
-import org.alfresco.rest.sdk.feign.oauth2.OAuth2FeignRequestInterceptor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
-import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientPropertiesRegistrationAdapter;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
+import org.alfresco.rest.sdk.feign.config.BasicAuthConfiguration;
+import org.alfresco.rest.sdk.feign.config.DelegatedAuthenticationConfiguration;
+import org.alfresco.rest.sdk.feign.config.OAuth2Configuration;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.authentication.AnonymousAuthenticationToken;
-import org.springframework.security.core.authority.AuthorityUtils;
-import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
-import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService;
-import org.springframework.security.oauth2.client.OAuth2AuthorizationContext;
-import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProvider;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
-import org.springframework.security.oauth2.client.registration.ClientRegistration;
-import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
-import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.context.annotation.Import;
 
 /**
  * Feign client Spring configuration that provides support for different authentication methods. Currently, supported methods are:
@@ -53,109 +31,7 @@ import org.springframework.security.oauth2.client.registration.InMemoryClientReg
  * </ul>
  */
 @Configuration
-@EnableConfigurationProperties({OAuth2ClientProperties.class})
+@Import({BasicAuthConfiguration.class, OAuth2Configuration.class, DelegatedAuthenticationConfiguration.class})
 public class ClientConfiguration {
 
-    /**
-     * Configuration for basic authentication. It configures a {@link BasicAuthRequestInterceptor} that uses the credentials configured in the properties
-     * <code>content.service.security.basicAuth.username</code> and <code>content.service.security.basicAuth.password</code>.
-     */
-    @Configuration
-    @ConditionalOnProperty("content.service.security.basicAuth.username")
-    protected static class BasicAuthConfiguration {
-
-        @Value("${content.service.security.basicAuth.username:#{null}}")
-        private String basicAuthUsername;
-        @Value("${content.service.security.basicAuth.password:#{null}}")
-        private String basicAuthPassword;
-
-        @Bean
-        @ConditionalOnProperty("content.service.security.basicAuth.username")
-        public BasicAuthRequestInterceptor basicAuthRequestInterceptor() {
-            return new BasicAuthRequestInterceptor(this.basicAuthUsername, this.basicAuthPassword);
-        }
-    }
-
-    /**
-     * Configuration for OAuth2 authentication flows. It configures a {@link OAuth2FeignRequestInterceptor} that retrieves the access token and generates the
-     * authorization header with the bearer. This is based in the OAuth2 support provided by the Spring Security module. So, the configuration must be done
-     * using the corresponding properties. The configuration of the client must be done using the properties
-     * <code>spring.security.oauth2.client.registration.alfresco-rest-api.xxxx</code>.
-     */
-    @Configuration
-    @ConditionalOnProperty("spring.security.oauth2.client.registration.alfresco-rest-api.provider")
-    protected static class OAuth2Configuration {
-
-        private static final String OAUTH2_CLIENT_REGISTRATION_ID = "alfresco-rest-api";
-
-        @Value("${spring.security.oauth2.client.registration.alfresco-rest-api.username:#{null}}")
-        private String oAuth2Username;
-        @Value("${spring.security.oauth2.client.registration.alfresco-rest-api.password:#{null}}")
-        private String oAuth2Password;
-
-        @Bean
-        @ConditionalOnMissingBean({ClientRegistrationRepository.class})
-        public InMemoryClientRegistrationRepository clientRegistrationRepository(OAuth2ClientProperties properties) {
-            List<ClientRegistration> registrations = new ArrayList(OAuth2ClientPropertiesRegistrationAdapter.getClientRegistrations(properties).values());
-            return new InMemoryClientRegistrationRepository(registrations);
-        }
-
-        @Bean
-        @ConditionalOnMissingBean({OAuth2AuthorizedClientService.class})
-        public InMemoryOAuth2AuthorizedClientService authorizedClientService(ClientRegistrationRepository clientRegistrationRepository) {
-            return new InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository);
-        }
-
-        @Bean
-        @ConditionalOnMissingBean
-        public OAuth2AuthorizedClientProvider oAuth2AuthorizedClientProvider() {
-            return OAuth2AuthorizedClientProviderBuilder.builder()
-                    .clientCredentials()
-                    .password()
-                    .build();
-        }
-
-        @Bean
-        @ConditionalOnMissingBean
-        public OAuth2AuthorizedClientManager authorizedClientManager(final ClientRegistrationRepository clientRegistrationRepository,
-                final OAuth2AuthorizedClientService authorizedClientService, OAuth2AuthorizedClientProvider oAuth2AuthorizedClientProvider) {
-            AuthorizedClientServiceOAuth2AuthorizedClientManager authorizedClientServiceOAuth2AuthorizedClientManager =
-                    new AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientService);
-            authorizedClientServiceOAuth2AuthorizedClientManager.setAuthorizedClientProvider(oAuth2AuthorizedClientProvider);
-            authorizedClientServiceOAuth2AuthorizedClientManager.setContextAttributesMapper(OAuth2AuthorizeRequest::getAttributes);
-            return authorizedClientServiceOAuth2AuthorizedClientManager;
-        }
-
-        @Bean
-        public OAuth2AuthorizeRequest oAuth2AuthorizeRequest() {
-            return OAuth2AuthorizeRequest.withClientRegistrationId(OAUTH2_CLIENT_REGISTRATION_ID)
-                    .principal(new AnonymousAuthenticationToken("feignClient", "feignClient",
-                            AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")))
-                    .attribute(OAuth2AuthorizationContext.USERNAME_ATTRIBUTE_NAME, oAuth2Username)
-                    .attribute(OAuth2AuthorizationContext.PASSWORD_ATTRIBUTE_NAME, oAuth2Password)
-                    .build();
-        }
-
-        @Bean
-        public OAuth2FeignRequestInterceptor requestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager,
-                OAuth2AuthorizeRequest oAuth2AuthorizeRequest) {
-            return new OAuth2FeignRequestInterceptor(oAuth2AuthorizedClientManager, oAuth2AuthorizeRequest);
-        }
-    }
-
-    /**
-     * Configuration for external delegated authentication mechanism. This must be provided by the integrator of the SDK in the form of a bean that implements
-     * the interface {@link DelegatedAuthenticationRequestInterceptor}. This authentication method is enabled via the property
-     * <code>content.service.security.delegated</code>.
-     */
-    @Configuration
-    @ConditionalOnProperty("content.service.security.delegated")
-    protected static class DelegatedAuthenticationConfiguration {
-
-        @Bean
-        public DelegatedAuthenticationRequestInterceptor delegatedAuthenticationRequestInterceptor(DelegatedAuthenticationProvider
-                delegatedAuthenticationProvider) {
-            return new DelegatedAuthenticationRequestInterceptor(delegatedAuthenticationProvider);
-        }
-    }
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/src/main/resources/templates/libraries/spring-cloud/clientConfiguration.mustache
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/src/main/resources/templates/libraries/spring-cloud/clientConfiguration.mustache
@@ -32,18 +32,18 @@ import org.springframework.security.oauth2.core.OAuth2AccessToken;
 public class ClientConfiguration {
 
   @Configuration
-  @ConditionalOnProperty(name = "{{{title}}}.security.{{{name}}}.username")
+  @ConditionalOnProperty("content.service.security.basicAuth.username")
   protected static class BasicAuthConfiguration {
 
-    {{=<% %>=}}@Value("${<%title%>.security.<%name%>.username:}")<%={{ }}=%>
-    private String {{{name}}}Username;
-    {{=<% %>=}}@Value("${<%title%>.security.<%name%>.password:}")<%={{ }}=%>
-    private String {{{name}}}Password;
+    @Value("${content.service.security.basicAuth.username:#{null}}")
+    private String basicAuthUsername;
+    @Value("${content.service.security.basicAuth.password:#{null}}")
+    private String basicAuthPassword;
 
     @Bean
-    @ConditionalOnProperty("{{{title}}}.security.{{{name}}}.username")
+    @ConditionalOnProperty("content.service.security.basicAuth.username")
     public BasicAuthRequestInterceptor basicAuthRequestInterceptor() {
-      return new BasicAuthRequestInterceptor(this.{{{name}}}Username, this.{{{name}}}Password);
+      return new BasicAuthRequestInterceptor(this.basicAuthUsername, this.basicAuthPassword);
     }
   }
 

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/src/main/resources/templates/libraries/spring-cloud/clientConfiguration.mustache
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/src/main/resources/templates/libraries/spring-cloud/clientConfiguration.mustache
@@ -1,32 +1,10 @@
 package {{configPackage}};
 
-import feign.auth.BasicAuthRequestInterceptor;
-import java.util.ArrayList;
-import java.util.List;
-import org.alfresco.rest.sdk.feign.DelegatedAuthenticationProvider;
-import org.alfresco.rest.sdk.feign.DelegatedAuthenticationRequestInterceptor;
-import org.alfresco.rest.sdk.feign.oauth2.OAuth2FeignRequestInterceptor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
-import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientPropertiesRegistrationAdapter;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
+import org.alfresco.rest.sdk.feign.config.BasicAuthConfiguration;
+import org.alfresco.rest.sdk.feign.config.DelegatedAuthenticationConfiguration;
+import org.alfresco.rest.sdk.feign.config.OAuth2Configuration;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.authentication.AnonymousAuthenticationToken;
-import org.springframework.security.core.authority.AuthorityUtils;
-import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
-import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService;
-import org.springframework.security.oauth2.client.OAuth2AuthorizationContext;
-import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProvider;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
-import org.springframework.security.oauth2.client.registration.ClientRegistration;
-import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
-import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.context.annotation.Import;
 
 /**
  * Feign client Spring configuration that provides support for different authentication methods. Currently, supported methods are:
@@ -38,109 +16,7 @@ import org.springframework.security.oauth2.client.registration.InMemoryClientReg
  * </ul>
  */
 @Configuration
-@EnableConfigurationProperties({OAuth2ClientProperties.class})
+@Import({BasicAuthConfiguration.class, OAuth2Configuration.class, DelegatedAuthenticationConfiguration.class})
 public class ClientConfiguration {
 
-    /**
-     * Configuration for basic authentication. It configures a {@link BasicAuthRequestInterceptor} that uses the credentials configured in the properties
-     * <code>content.service.security.basicAuth.username</code> and <code>content.service.security.basicAuth.password</code>.
-     */
-    @Configuration
-    @ConditionalOnProperty("content.service.security.basicAuth.username")
-    protected static class BasicAuthConfiguration {
-
-        @Value("${content.service.security.basicAuth.username:#{null}}")
-        private String basicAuthUsername;
-        @Value("${content.service.security.basicAuth.password:#{null}}")
-        private String basicAuthPassword;
-
-        @Bean
-        @ConditionalOnProperty("content.service.security.basicAuth.username")
-        public BasicAuthRequestInterceptor basicAuthRequestInterceptor() {
-            return new BasicAuthRequestInterceptor(this.basicAuthUsername, this.basicAuthPassword);
-        }
-    }
-
-    /**
-     * Configuration for OAuth2 authentication flows. It configures a {@link OAuth2FeignRequestInterceptor} that retrieves the access token and generates the
-     * authorization header with the bearer. This is based in the OAuth2 support provided by the Spring Security module. So, the configuration must be done
-     * using the corresponding properties. The configuration of the client must be done using the properties
-     * <code>spring.security.oauth2.client.registration.alfresco-rest-api.xxxx</code>.
-     */
-    @Configuration
-    @ConditionalOnProperty("spring.security.oauth2.client.registration.alfresco-rest-api.provider")
-    protected static class OAuth2Configuration {
-
-        private static final String OAUTH2_CLIENT_REGISTRATION_ID = "alfresco-rest-api";
-
-        @Value("${spring.security.oauth2.client.registration.alfresco-rest-api.username:#{null}}")
-        private String oAuth2Username;
-        @Value("${spring.security.oauth2.client.registration.alfresco-rest-api.password:#{null}}")
-        private String oAuth2Password;
-
-        @Bean
-        @ConditionalOnMissingBean({ClientRegistrationRepository.class})
-        public InMemoryClientRegistrationRepository clientRegistrationRepository(OAuth2ClientProperties properties) {
-            List<ClientRegistration> registrations = new ArrayList(OAuth2ClientPropertiesRegistrationAdapter.getClientRegistrations(properties).values());
-            return new InMemoryClientRegistrationRepository(registrations);
-        }
-
-        @Bean
-        @ConditionalOnMissingBean({OAuth2AuthorizedClientService.class})
-        public InMemoryOAuth2AuthorizedClientService authorizedClientService(ClientRegistrationRepository clientRegistrationRepository) {
-            return new InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository);
-        }
-
-        @Bean
-        @ConditionalOnMissingBean
-        public OAuth2AuthorizedClientProvider oAuth2AuthorizedClientProvider() {
-            return OAuth2AuthorizedClientProviderBuilder.builder()
-                    .clientCredentials()
-                    .password()
-                    .build();
-        }
-
-        @Bean
-        @ConditionalOnMissingBean
-        public OAuth2AuthorizedClientManager authorizedClientManager(final ClientRegistrationRepository clientRegistrationRepository,
-                final OAuth2AuthorizedClientService authorizedClientService, OAuth2AuthorizedClientProvider oAuth2AuthorizedClientProvider) {
-            AuthorizedClientServiceOAuth2AuthorizedClientManager authorizedClientServiceOAuth2AuthorizedClientManager =
-                    new AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientService);
-            authorizedClientServiceOAuth2AuthorizedClientManager.setAuthorizedClientProvider(oAuth2AuthorizedClientProvider);
-            authorizedClientServiceOAuth2AuthorizedClientManager.setContextAttributesMapper(OAuth2AuthorizeRequest::getAttributes);
-            return authorizedClientServiceOAuth2AuthorizedClientManager;
-        }
-
-        @Bean
-        public OAuth2AuthorizeRequest oAuth2AuthorizeRequest() {
-            return OAuth2AuthorizeRequest.withClientRegistrationId(OAUTH2_CLIENT_REGISTRATION_ID)
-                    .principal(new AnonymousAuthenticationToken("feignClient", "feignClient",
-                            AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")))
-                    .attribute(OAuth2AuthorizationContext.USERNAME_ATTRIBUTE_NAME, oAuth2Username)
-                    .attribute(OAuth2AuthorizationContext.PASSWORD_ATTRIBUTE_NAME, oAuth2Password)
-                    .build();
-        }
-
-        @Bean
-        public OAuth2FeignRequestInterceptor requestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager,
-                OAuth2AuthorizeRequest oAuth2AuthorizeRequest) {
-            return new OAuth2FeignRequestInterceptor(oAuth2AuthorizedClientManager, oAuth2AuthorizeRequest);
-        }
-    }
-
-    /**
-     * Configuration for external delegated authentication mechanism. This must be provided by the integrator of the SDK in the form of a bean that implements
-     * the interface {@link DelegatedAuthenticationRequestInterceptor}. This authentication method is enabled via the property
-     * <code>content.service.security.delegated</code>.
-     */
-    @Configuration
-    @ConditionalOnProperty("content.service.security.delegated")
-    protected static class DelegatedAuthenticationConfiguration {
-
-        @Bean
-        public DelegatedAuthenticationRequestInterceptor delegatedAuthenticationRequestInterceptor(DelegatedAuthenticationProvider
-                delegatedAuthenticationProvider) {
-            return new DelegatedAuthenticationRequestInterceptor(delegatedAuthenticationProvider);
-        }
-    }
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/src/main/resources/templates/libraries/spring-cloud/clientConfiguration.mustache
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/src/main/resources/templates/libraries/spring-cloud/clientConfiguration.mustache
@@ -1,12 +1,11 @@
 package {{configPackage}};
 
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-
-import feign.RequestInterceptor;
-import feign.RequestTemplate;
 import feign.auth.BasicAuthRequestInterceptor;
 import java.util.ArrayList;
 import java.util.List;
+import org.alfresco.rest.sdk.feign.DelegatedAuthenticationProvider;
+import org.alfresco.rest.sdk.feign.DelegatedAuthenticationRequestInterceptor;
+import org.alfresco.rest.sdk.feign.oauth2.OAuth2FeignRequestInterceptor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -19,85 +18,129 @@ import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.OAuth2AuthorizationContext;
 import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProvider;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
-import org.springframework.security.oauth2.core.OAuth2AccessToken;
 
+/**
+ * Feign client Spring configuration that provides support for different authentication methods. Currently, supported methods are:
+ * <ul>
+ *     <li>Basic Authentication</li>
+ *     <li>OAuth2 - Client credentials flow</li>
+ *     <li>OAuth2 - Password flow</li>
+ *     <li>Delegated (external) authentication</li>
+ * </ul>
+ */
 @Configuration
 @EnableConfigurationProperties({OAuth2ClientProperties.class})
 public class ClientConfiguration {
 
-  @Configuration
-  @ConditionalOnProperty("content.service.security.basicAuth.username")
-  protected static class BasicAuthConfiguration {
-
-    @Value("${content.service.security.basicAuth.username:#{null}}")
-    private String basicAuthUsername;
-    @Value("${content.service.security.basicAuth.password:#{null}}")
-    private String basicAuthPassword;
-
-    @Bean
+    /**
+     * Configuration for basic authentication. It configures a {@link BasicAuthRequestInterceptor} that uses the credentials configured in the properties
+     * <code>content.service.security.basicAuth.username</code> and <code>content.service.security.basicAuth.password</code>.
+     */
+    @Configuration
     @ConditionalOnProperty("content.service.security.basicAuth.username")
-    public BasicAuthRequestInterceptor basicAuthRequestInterceptor() {
-      return new BasicAuthRequestInterceptor(this.basicAuthUsername, this.basicAuthPassword);
-    }
-  }
+    protected static class BasicAuthConfiguration {
 
-  @Configuration
-  @ConditionalOnProperty("spring.security.oauth2.client.registration.alfresco-rest-api.provider")
-  protected static class OAuth2Configuration {
+        @Value("${content.service.security.basicAuth.username:#{null}}")
+        private String basicAuthUsername;
+        @Value("${content.service.security.basicAuth.password:#{null}}")
+        private String basicAuthPassword;
 
-    @Bean
-    @ConditionalOnMissingBean({ClientRegistrationRepository.class})
-    public InMemoryClientRegistrationRepository clientRegistrationRepository(OAuth2ClientProperties properties) {
-      List<ClientRegistration> registrations = new ArrayList(OAuth2ClientPropertiesRegistrationAdapter.getClientRegistrations(properties).values());
-      return new InMemoryClientRegistrationRepository(registrations);
+        @Bean
+        @ConditionalOnProperty("content.service.security.basicAuth.username")
+        public BasicAuthRequestInterceptor basicAuthRequestInterceptor() {
+            return new BasicAuthRequestInterceptor(this.basicAuthUsername, this.basicAuthPassword);
+        }
     }
 
-    @Bean
-    @ConditionalOnMissingBean({OAuth2AuthorizedClientService.class})
-    public InMemoryOAuth2AuthorizedClientService authorizedClientService(ClientRegistrationRepository clientRegistrationRepository) {
-      return new InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository);
+    /**
+     * Configuration for OAuth2 authentication flows. It configures a {@link OAuth2FeignRequestInterceptor} that retrieves the access token and generates the
+     * authorization header with the bearer. This is based in the OAuth2 support provided by the Spring Security module. So, the configuration must be done
+     * using the corresponding properties. The configuration of the client must be done using the properties
+     * <code>spring.security.oauth2.client.registration.alfresco-rest-api.xxxx</code>.
+     */
+    @Configuration
+    @ConditionalOnProperty("spring.security.oauth2.client.registration.alfresco-rest-api.provider")
+    protected static class OAuth2Configuration {
+
+        private static final String OAUTH2_CLIENT_REGISTRATION_ID = "alfresco-rest-api";
+
+        @Value("${spring.security.oauth2.client.registration.alfresco-rest-api.username:#{null}}")
+        private String oAuth2Username;
+        @Value("${spring.security.oauth2.client.registration.alfresco-rest-api.password:#{null}}")
+        private String oAuth2Password;
+
+        @Bean
+        @ConditionalOnMissingBean({ClientRegistrationRepository.class})
+        public InMemoryClientRegistrationRepository clientRegistrationRepository(OAuth2ClientProperties properties) {
+            List<ClientRegistration> registrations = new ArrayList(OAuth2ClientPropertiesRegistrationAdapter.getClientRegistrations(properties).values());
+            return new InMemoryClientRegistrationRepository(registrations);
+        }
+
+        @Bean
+        @ConditionalOnMissingBean({OAuth2AuthorizedClientService.class})
+        public InMemoryOAuth2AuthorizedClientService authorizedClientService(ClientRegistrationRepository clientRegistrationRepository) {
+            return new InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository);
+        }
+
+        @Bean
+        @ConditionalOnMissingBean
+        public OAuth2AuthorizedClientProvider oAuth2AuthorizedClientProvider() {
+            return OAuth2AuthorizedClientProviderBuilder.builder()
+                    .clientCredentials()
+                    .password()
+                    .build();
+        }
+
+        @Bean
+        @ConditionalOnMissingBean
+        public OAuth2AuthorizedClientManager authorizedClientManager(final ClientRegistrationRepository clientRegistrationRepository,
+                final OAuth2AuthorizedClientService authorizedClientService, OAuth2AuthorizedClientProvider oAuth2AuthorizedClientProvider) {
+            AuthorizedClientServiceOAuth2AuthorizedClientManager authorizedClientServiceOAuth2AuthorizedClientManager =
+                    new AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientService);
+            authorizedClientServiceOAuth2AuthorizedClientManager.setAuthorizedClientProvider(oAuth2AuthorizedClientProvider);
+            authorizedClientServiceOAuth2AuthorizedClientManager.setContextAttributesMapper(OAuth2AuthorizeRequest::getAttributes);
+            return authorizedClientServiceOAuth2AuthorizedClientManager;
+        }
+
+        @Bean
+        public OAuth2AuthorizeRequest oAuth2AuthorizeRequest() {
+            return OAuth2AuthorizeRequest.withClientRegistrationId(OAUTH2_CLIENT_REGISTRATION_ID)
+                    .principal(new AnonymousAuthenticationToken("feignClient", "feignClient",
+                            AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")))
+                    .attribute(OAuth2AuthorizationContext.USERNAME_ATTRIBUTE_NAME, oAuth2Username)
+                    .attribute(OAuth2AuthorizationContext.PASSWORD_ATTRIBUTE_NAME, oAuth2Password)
+                    .build();
+        }
+
+        @Bean
+        public OAuth2FeignRequestInterceptor requestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager,
+                OAuth2AuthorizeRequest oAuth2AuthorizeRequest) {
+            return new OAuth2FeignRequestInterceptor(oAuth2AuthorizedClientManager, oAuth2AuthorizeRequest);
+        }
     }
 
-    @Bean
-    @ConditionalOnMissingBean
-    public OAuth2AuthorizedClientManager authorizedClientManager(final ClientRegistrationRepository clientRegistrationRepository,
-          final OAuth2AuthorizedClientService authorizedClientService) {
-      return new AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientService);
+    /**
+     * Configuration for external delegated authentication mechanism. This must be provided by the integrator of the SDK in the form of a bean that implements
+     * the interface {@link DelegatedAuthenticationRequestInterceptor}. This authentication method is enabled via the property
+     * <code>content.service.security.delegated</code>.
+     */
+    @Configuration
+    @ConditionalOnProperty("content.service.security.delegated")
+    protected static class DelegatedAuthenticationConfiguration {
+
+        @Bean
+        public DelegatedAuthenticationRequestInterceptor delegatedAuthenticationRequestInterceptor(DelegatedAuthenticationProvider
+                delegatedAuthenticationProvider) {
+            return new DelegatedAuthenticationRequestInterceptor(delegatedAuthenticationProvider);
+        }
     }
-
-    @Bean
-    public OAuth2FeignRequestInterceptor requestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager) {
-      return new OAuth2FeignRequestInterceptor(oAuth2AuthorizedClientManager,
-              OAuth2AuthorizeRequest.withClientRegistrationId("alfresco-rest-api")
-                      .principal(new AnonymousAuthenticationToken("feignClient", "feignClient", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")))
-                      .build());
-    }
-
-    public class OAuth2FeignRequestInterceptor implements RequestInterceptor {
-
-      private final OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager;
-      private final OAuth2AuthorizeRequest oAuth2AuthorizeRequest;
-
-      public OAuth2FeignRequestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager, OAuth2AuthorizeRequest oAuth2AuthorizeRequest) {
-        this.oAuth2AuthorizedClientManager = oAuth2AuthorizedClientManager;
-        this.oAuth2AuthorizeRequest = oAuth2AuthorizeRequest;
-      }
-
-      @Override
-      public void apply(RequestTemplate template) {
-        template.header(AUTHORIZATION,getAuthorizationToken());
-      }
-
-      private String getAuthorizationToken() {
-        final OAuth2AccessToken accessToken = oAuth2AuthorizedClientManager.authorize(oAuth2AuthorizeRequest).getAccessToken();
-        return String.format("%s %s", accessToken.getTokenType().getValue(), accessToken.getTokenValue());
-      }
-    }
-  }
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/src/main/resources/templates/libraries/spring-cloud/clientConfiguration.mustache
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/src/main/resources/templates/libraries/spring-cloud/clientConfiguration.mustache
@@ -1,96 +1,103 @@
 package {{configPackage}};
 
-{{#authMethods}}{{#isBasic}}import feign.auth.BasicAuthRequestInterceptor;{{/isBasic}}{{/authMethods}}
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
+import feign.auth.BasicAuthRequestInterceptor;
+import java.util.ArrayList;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientPropertiesRegistrationAdapter;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-{{#authMethods}}{{#isOAuth}}import org.springframework.cloud.openfeign.security.OAuth2FeignRequestInterceptor;{{/isOAuth}}{{/authMethods}}
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
 
 @Configuration
-@EnableConfigurationProperties
+@EnableConfigurationProperties({OAuth2ClientProperties.class})
 public class ClientConfiguration {
 
-{{#authMethods}}
-    {{#isBasic}}
-  {{=<% %>=}}@Value("${<%title%>.security.<%name%>.username:}")<%={{ }}=%>
-  private String {{{name}}}Username;
-
-  {{=<% %>=}}@Value("${<%title%>.security.<%name%>.password:}")<%={{ }}=%>
-  private String {{{name}}}Password;
-
-  @Bean
+  @Configuration
   @ConditionalOnProperty(name = "{{{title}}}.security.{{{name}}}.username")
-  public BasicAuthRequestInterceptor {{{name}}}RequestInterceptor() {
-    return new BasicAuthRequestInterceptor(this.{{{name}}}Username, this.{{{name}}}Password);
+  protected static class BasicAuthConfiguration {
+
+    {{=<% %>=}}@Value("${<%title%>.security.<%name%>.username:}")<%={{ }}=%>
+    private String {{{name}}}Username;
+    {{=<% %>=}}@Value("${<%title%>.security.<%name%>.password:}")<%={{ }}=%>
+    private String {{{name}}}Password;
+
+    @Bean
+    @ConditionalOnProperty("{{{title}}}.security.{{{name}}}.username")
+    public BasicAuthRequestInterceptor basicAuthRequestInterceptor() {
+      return new BasicAuthRequestInterceptor(this.{{{name}}}Username, this.{{{name}}}Password);
+    }
   }
 
-    {{/isBasic}}
-    {{#isApiKey}}
-  {{=<% %>=}}@Value("${<%title%>.security.<%name%>.key:}")<%={{ }}=%>
-  private String {{{name}}}Key;
+  @Configuration
+  @ConditionalOnProperty("spring.security.oauth2.client.registration.alfresco-rest-api.provider")
+  protected static class OAuth2Configuration {
 
-  @Bean
-  @ConditionalOnProperty(name = "{{{title}}}.security.{{{name}}}.key")
-  public ApiKeyRequestInterceptor {{{name}}}RequestInterceptor() {
-    return new ApiKeyRequestInterceptor({{#isKeyInHeader}}"header"{{/isKeyInHeader}}{{^isKeyInHeader}}"query"{{/isKeyInHeader}}, "{{{keyParamName}}}", this.{{{name}}}Key);
+    @Bean
+    @ConditionalOnMissingBean({ClientRegistrationRepository.class})
+    public InMemoryClientRegistrationRepository clientRegistrationRepository(OAuth2ClientProperties properties) {
+      List<ClientRegistration> registrations = new ArrayList(OAuth2ClientPropertiesRegistrationAdapter.getClientRegistrations(properties).values());
+      return new InMemoryClientRegistrationRepository(registrations);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean({OAuth2AuthorizedClientService.class})
+    public InMemoryOAuth2AuthorizedClientService authorizedClientService(ClientRegistrationRepository clientRegistrationRepository) {
+      return new InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public OAuth2AuthorizedClientManager authorizedClientManager(final ClientRegistrationRepository clientRegistrationRepository,
+          final OAuth2AuthorizedClientService authorizedClientService) {
+      return new AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientService);
+    }
+
+    @Bean
+    public OAuth2FeignRequestInterceptor requestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager) {
+      return new OAuth2FeignRequestInterceptor(oAuth2AuthorizedClientManager,
+              OAuth2AuthorizeRequest.withClientRegistrationId("alfresco-rest-api")
+                      .principal(new AnonymousAuthenticationToken("feignClient", "feignClient", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")))
+                      .build());
+    }
+
+    public class OAuth2FeignRequestInterceptor implements RequestInterceptor {
+
+      private final OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager;
+      private final OAuth2AuthorizeRequest oAuth2AuthorizeRequest;
+
+      public OAuth2FeignRequestInterceptor(OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager, OAuth2AuthorizeRequest oAuth2AuthorizeRequest) {
+        this.oAuth2AuthorizedClientManager = oAuth2AuthorizedClientManager;
+        this.oAuth2AuthorizeRequest = oAuth2AuthorizeRequest;
+      }
+
+      @Override
+      public void apply(RequestTemplate template) {
+        template.header(AUTHORIZATION,getAuthorizationToken());
+      }
+
+      private String getAuthorizationToken() {
+        final OAuth2AccessToken accessToken = oAuth2AuthorizedClientManager.authorize(oAuth2AuthorizeRequest).getAccessToken();
+        return String.format("%s %s", accessToken.getTokenType().getValue(), accessToken.getTokenValue());
+      }
+    }
   }
-
-    {{/isApiKey}}
-    {{#isOAuth}}
-  @Bean
-  @ConditionalOnProperty("{{{title}}}.security.{{{name}}}.client-id")
-  public OAuth2FeignRequestInterceptor {{{name}}}RequestInterceptor() {
-    return new OAuth2FeignRequestInterceptor(new DefaultOAuth2ClientContext(), {{{name}}}ResourceDetails());
-  }
-
-        {{#isCode}}
-  @Bean
-  @ConditionalOnProperty("{{{title}}}.security.{{{name}}}.client-id")
-  @ConfigurationProperties("{{{title}}}.security.{{{name}}}")
-  public AuthorizationCodeResourceDetails {{{name}}}ResourceDetails() {
-    AuthorizationCodeResourceDetails details = new AuthorizationCodeResourceDetails();
-    details.setAccessTokenUri("{{{tokenUrl}}}");
-    details.setUserAuthorizationUri("{{{authorizationUrl}}}");
-    return details;
-  }
-
-        {{/isCode}}
-        {{#isPassword}}
-  @Bean
-  @ConditionalOnProperty("{{{title}}}.security.{{{name}}}.client-id")
-  @ConfigurationProperties("{{{title}}}.security.{{{name}}}")
-  public ResourceOwnerPasswordResourceDetails {{{name}}}ResourceDetails() {
-    ResourceOwnerPasswordResourceDetails details = new ResourceOwnerPasswordResourceDetails();
-    details.setAccessTokenUri("{{{tokenUrl}}}");
-    return details;
-  }
-
-        {{/isPassword}}
-        {{#isApplication}}
-  @Bean
-  @ConditionalOnProperty("{{{title}}}.security.{{{name}}}.client-id")
-  @ConfigurationProperties("{{{title}}}.security.{{{name}}}")
-  public ClientCredentialsResourceDetails {{{name}}}ResourceDetails() {
-    ClientCredentialsResourceDetails details = new ClientCredentialsResourceDetails();
-    details.setAccessTokenUri("{{{tokenUrl}}}");
-    return details;
-  }
-
-        {{/isApplication}}
-        {{#isImplicit}}
-  @Bean
-  @ConditionalOnProperty("{{{title}}}.security.{{{name}}}.client-id")
-  @ConfigurationProperties("{{{title}}}.security.{{{name}}}")
-  public ImplicitResourceDetails {{{name}}}ResourceDetails() {
-    ImplicitResourceDetails details = new ImplicitResourceDetails();
-    details.setUserAuthorizationUri("{{{authorizationUrl}}}");
-    return details;
-  }
-
-        {{/isImplicit}}
-    {{/isOAuth}}
-{{/authMethods}}
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/src/main/resources/templates/libraries/spring-cloud/pom.mustache
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/src/main/resources/templates/libraries/spring-cloud/pom.mustache
@@ -24,6 +24,10 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-oauth2-client</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.alfresco</groupId>
+      <artifactId>alfresco-java-rest-api-common</artifactId>
+    </dependency>
     {{#withXml}}
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>

--- a/alfresco-java-rest-api/pom.xml
+++ b/alfresco-java-rest-api/pom.xml
@@ -15,6 +15,7 @@
   <name>Alfresco Java Rest API :: Parent</name>
 
   <modules>
+    <module>alfresco-java-rest-api-common</module>
     <module>alfresco-java-rest-api-lib</module>
     <module>alfresco-java-rest-api-spring-boot</module>
     <module>alfresco-java-rest-api-spring-boot-starter</module>
@@ -43,6 +44,11 @@
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-openfeign-dependencies</artifactId>
         <version>${spring-cloud.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.alfresco</groupId>
+        <artifactId>alfresco-java-rest-api-common</artifactId>
+        <version>${project.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
- Add support for OAuth2 authentication in the REST API feign clients (client-credentials and passwords flows supported).
- Add support for delegated external authentication in the REST API feign clients.