### PR TITLE
NOJIRA Remove decode404 from feign clients

### DIFF
--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/alfresco-event-gateway-api/src/main/java/org/alfresco/gateway/handler/SubscriptionsApiClient.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/alfresco-event-gateway-api/src/main/java/org/alfresco/gateway/handler/SubscriptionsApiClient.java
@@ -18,6 +18,6 @@ package org.alfresco.gateway.handler;
 import org.springframework.cloud.openfeign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name = "alfrescoSubscriptionsApi", url = "${event.gateway.service.url}", path = "${event.gateway.service.path}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfrescoSubscriptionsApi", url = "${event.gateway.service.url}", path = "${event.gateway.service.path}", configuration = ClientConfiguration.class)
 public interface SubscriptionsApiClient extends SubscriptionsApi {
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/org/alfresco/core/handler/ActionsApiClient.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/org/alfresco/core/handler/ActionsApiClient.java
@@ -18,6 +18,6 @@ package org.alfresco.core.handler;
 import org.springframework.cloud.openfeign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name = "alfrescoActionsApi", url = "${content.service.url}", path = "${content.service.path}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfrescoActionsApi", url = "${content.service.url}", path = "${content.service.path}", configuration = ClientConfiguration.class)
 public interface ActionsApiClient extends ActionsApi {
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/org/alfresco/core/handler/ActivitiesApiClient.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/org/alfresco/core/handler/ActivitiesApiClient.java
@@ -18,6 +18,6 @@ package org.alfresco.core.handler;
 import org.springframework.cloud.openfeign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name = "alfrescoActivitiesApi", url = "${content.service.url}", path = "${content.service.path}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfrescoActivitiesApi", url = "${content.service.url}", path = "${content.service.path}", configuration = ClientConfiguration.class)
 public interface ActivitiesApiClient extends ActivitiesApi {
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/org/alfresco/core/handler/AuditApiClient.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/org/alfresco/core/handler/AuditApiClient.java
@@ -18,6 +18,6 @@ package org.alfresco.core.handler;
 import org.springframework.cloud.openfeign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name = "alfrescoAuditApi", url = "${content.service.url}", path = "${content.service.path}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfrescoAuditApi", url = "${content.service.url}", path = "${content.service.path}", configuration = ClientConfiguration.class)
 public interface AuditApiClient extends AuditApi {
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/org/alfresco/core/handler/CommentsApiClient.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/org/alfresco/core/handler/CommentsApiClient.java
@@ -18,6 +18,6 @@ package org.alfresco.core.handler;
 import org.springframework.cloud.openfeign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name = "alfrescoCommentsApi", url = "${content.service.url}", path = "${content.service.path}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfrescoCommentsApi", url = "${content.service.url}", path = "${content.service.path}", configuration = ClientConfiguration.class)
 public interface CommentsApiClient extends CommentsApi {
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/org/alfresco/core/handler/DownloadsApiClient.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/org/alfresco/core/handler/DownloadsApiClient.java
@@ -18,6 +18,6 @@ package org.alfresco.core.handler;
 import org.springframework.cloud.openfeign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name = "alfrescoDownloadsApi", url = "${content.service.url}", path = "${content.service.path}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfrescoDownloadsApi", url = "${content.service.url}", path = "${content.service.path}", configuration = ClientConfiguration.class)
 public interface DownloadsApiClient extends DownloadsApi {
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/org/alfresco/core/handler/FavoritesApiClient.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/org/alfresco/core/handler/FavoritesApiClient.java
@@ -18,6 +18,6 @@ package org.alfresco.core.handler;
 import org.springframework.cloud.openfeign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name = "alfrescoFavoritesApi", url = "${content.service.url}", path = "${content.service.path}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfrescoFavoritesApi", url = "${content.service.url}", path = "${content.service.path}", configuration = ClientConfiguration.class)
 public interface FavoritesApiClient extends FavoritesApi {
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/org/alfresco/core/handler/GroupsApiClient.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/org/alfresco/core/handler/GroupsApiClient.java
@@ -18,6 +18,6 @@ package org.alfresco.core.handler;
 import org.springframework.cloud.openfeign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name = "alfrescoGroupsApi", url = "${content.service.url}", path = "${content.service.path}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfrescoGroupsApi", url = "${content.service.url}", path = "${content.service.path}", configuration = ClientConfiguration.class)
 public interface GroupsApiClient extends GroupsApi {
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/org/alfresco/core/handler/NetworksApiClient.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/org/alfresco/core/handler/NetworksApiClient.java
@@ -18,6 +18,6 @@ package org.alfresco.core.handler;
 import org.springframework.cloud.openfeign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name = "alfrescoNetworksApi", url = "${content.service.url}", path = "${content.service.path}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfrescoNetworksApi", url = "${content.service.url}", path = "${content.service.path}", configuration = ClientConfiguration.class)
 public interface NetworksApiClient extends NetworksApi {
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/org/alfresco/core/handler/NodesApiClient.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/org/alfresco/core/handler/NodesApiClient.java
@@ -18,6 +18,6 @@ package org.alfresco.core.handler;
 import org.springframework.cloud.openfeign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name = "alfrescoNodesApi", url = "${content.service.url}", path = "${content.service.path}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfrescoNodesApi", url = "${content.service.url}", path = "${content.service.path}", configuration = ClientConfiguration.class)
 public interface NodesApiClient extends NodesApi {
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/org/alfresco/core/handler/PeopleApiClient.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/org/alfresco/core/handler/PeopleApiClient.java
@@ -18,6 +18,6 @@ package org.alfresco.core.handler;
 import org.springframework.cloud.openfeign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name = "alfrescoPeopleApi", url = "${content.service.url}", path = "${content.service.path}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfrescoPeopleApi", url = "${content.service.url}", path = "${content.service.path}", configuration = ClientConfiguration.class)
 public interface PeopleApiClient extends PeopleApi {
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/org/alfresco/core/handler/PreferencesApiClient.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/org/alfresco/core/handler/PreferencesApiClient.java
@@ -18,6 +18,6 @@ package org.alfresco.core.handler;
 import org.springframework.cloud.openfeign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name = "alfrescoPreferencesApi", url = "${content.service.url}", path = "${content.service.path}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfrescoPreferencesApi", url = "${content.service.url}", path = "${content.service.path}", configuration = ClientConfiguration.class)
 public interface PreferencesApiClient extends PreferencesApi {
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/org/alfresco/core/handler/ProbesApiClient.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/org/alfresco/core/handler/ProbesApiClient.java
@@ -18,6 +18,6 @@ package org.alfresco.core.handler;
 import org.springframework.cloud.openfeign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name = "alfrescoProbesApi", url = "${content.service.url}", path = "${content.service.path}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfrescoProbesApi", url = "${content.service.url}", path = "${content.service.path}", configuration = ClientConfiguration.class)
 public interface ProbesApiClient extends ProbesApi {
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/org/alfresco/core/handler/QueriesApiClient.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/org/alfresco/core/handler/QueriesApiClient.java
@@ -18,6 +18,6 @@ package org.alfresco.core.handler;
 import org.springframework.cloud.openfeign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name = "alfrescoQueriesApi", url = "${content.service.url}", path = "${content.service.path}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfrescoQueriesApi", url = "${content.service.url}", path = "${content.service.path}", configuration = ClientConfiguration.class)
 public interface QueriesApiClient extends QueriesApi {
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/org/alfresco/core/handler/RatingsApiClient.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/org/alfresco/core/handler/RatingsApiClient.java
@@ -18,6 +18,6 @@ package org.alfresco.core.handler;
 import org.springframework.cloud.openfeign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name = "alfrescoRatingsApi", url = "${content.service.url}", path = "${content.service.path}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfrescoRatingsApi", url = "${content.service.url}", path = "${content.service.path}", configuration = ClientConfiguration.class)
 public interface RatingsApiClient extends RatingsApi {
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/org/alfresco/core/handler/RenditionsApiClient.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/org/alfresco/core/handler/RenditionsApiClient.java
@@ -18,6 +18,6 @@ package org.alfresco.core.handler;
 import org.springframework.cloud.openfeign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name = "alfrescoRenditionsApi", url = "${content.service.url}", path = "${content.service.path}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfrescoRenditionsApi", url = "${content.service.url}", path = "${content.service.path}", configuration = ClientConfiguration.class)
 public interface RenditionsApiClient extends RenditionsApi {
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/org/alfresco/core/handler/SharedLinksApiClient.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/org/alfresco/core/handler/SharedLinksApiClient.java
@@ -18,6 +18,6 @@ package org.alfresco.core.handler;
 import org.springframework.cloud.openfeign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name = "alfrescoSharedLinksApi", url = "${content.service.url}", path = "${content.service.path}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfrescoSharedLinksApi", url = "${content.service.url}", path = "${content.service.path}", configuration = ClientConfiguration.class)
 public interface SharedLinksApiClient extends SharedLinksApi {
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/org/alfresco/core/handler/SitesApiClient.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/org/alfresco/core/handler/SitesApiClient.java
@@ -18,6 +18,6 @@ package org.alfresco.core.handler;
 import org.springframework.cloud.openfeign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name = "alfrescoSitesApi", url = "${content.service.url}", path = "${content.service.path}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfrescoSitesApi", url = "${content.service.url}", path = "${content.service.path}", configuration = ClientConfiguration.class)
 public interface SitesApiClient extends SitesApi {
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/org/alfresco/core/handler/TagsApiClient.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/org/alfresco/core/handler/TagsApiClient.java
@@ -18,6 +18,6 @@ package org.alfresco.core.handler;
 import org.springframework.cloud.openfeign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name = "alfrescoTagsApi", url = "${content.service.url}", path = "${content.service.path}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfrescoTagsApi", url = "${content.service.url}", path = "${content.service.path}", configuration = ClientConfiguration.class)
 public interface TagsApiClient extends TagsApi {
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/org/alfresco/core/handler/TrashcanApiClient.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/org/alfresco/core/handler/TrashcanApiClient.java
@@ -18,6 +18,6 @@ package org.alfresco.core.handler;
 import org.springframework.cloud.openfeign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name = "alfrescoTrashcanApi", url = "${content.service.url}", path = "${content.service.path}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfrescoTrashcanApi", url = "${content.service.url}", path = "${content.service.path}", configuration = ClientConfiguration.class)
 public interface TrashcanApiClient extends TrashcanApi {
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/org/alfresco/core/handler/VersionsApiClient.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api/src/main/java/org/alfresco/core/handler/VersionsApiClient.java
@@ -18,6 +18,6 @@ package org.alfresco.core.handler;
 import org.springframework.cloud.openfeign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name = "alfrescoVersionsApi", url = "${content.service.url}", path = "${content.service.path}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfrescoVersionsApi", url = "${content.service.url}", path = "${content.service.path}", configuration = ClientConfiguration.class)
 public interface VersionsApiClient extends VersionsApi {
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-discovery-rest-api/src/main/java/org/alfresco/discovery/handler/DiscoveryApiClient.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-discovery-rest-api/src/main/java/org/alfresco/discovery/handler/DiscoveryApiClient.java
@@ -18,6 +18,6 @@ package org.alfresco.discovery.handler;
 import org.springframework.cloud.openfeign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name = "alfrescoDiscoveryApi", url = "${content.service.url}", path = "${discovery.service.path}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfrescoDiscoveryApi", url = "${content.service.url}", path = "${discovery.service.path}", configuration = ClientConfiguration.class)
 public interface DiscoveryApiClient extends DiscoveryApi {
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-classification-rest-api/src/main/java/org/alfresco/governance/classification/handler/ClassificationGuidesApiClient.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-classification-rest-api/src/main/java/org/alfresco/governance/classification/handler/ClassificationGuidesApiClient.java
@@ -18,6 +18,6 @@ package org.alfresco.governance.classification.handler;
 import org.springframework.cloud.openfeign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name = "alfrescoClassificationGuidesApi", url = "${content.service.url}", path = "${governance.service.path}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfrescoClassificationGuidesApi", url = "${content.service.url}", path = "${governance.service.path}", configuration = ClientConfiguration.class)
 public interface ClassificationGuidesApiClient extends ClassificationGuidesApi {
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-classification-rest-api/src/main/java/org/alfresco/governance/classification/handler/ClassificationReasonsApiClient.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-classification-rest-api/src/main/java/org/alfresco/governance/classification/handler/ClassificationReasonsApiClient.java
@@ -18,6 +18,6 @@ package org.alfresco.governance.classification.handler;
 import org.springframework.cloud.openfeign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name = "alfrescoClassificationReasonsApi", url = "${content.service.url}", path = "${governance.service.path}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfrescoClassificationReasonsApi", url = "${content.service.url}", path = "${governance.service.path}", configuration = ClientConfiguration.class)
 public interface ClassificationReasonsApiClient extends ClassificationReasonsApi {
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-classification-rest-api/src/main/java/org/alfresco/governance/classification/handler/DeclassificationExemptionsApiClient.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-classification-rest-api/src/main/java/org/alfresco/governance/classification/handler/DeclassificationExemptionsApiClient.java
@@ -18,6 +18,6 @@ package org.alfresco.governance.classification.handler;
 import org.springframework.cloud.openfeign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name = "alfrescoDeclassificationExemptionsApi", url = "${content.service.url}", path = "${governance.service.path}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfrescoDeclassificationExemptionsApi", url = "${content.service.url}", path = "${governance.service.path}", configuration = ClientConfiguration.class)
 public interface DeclassificationExemptionsApiClient extends DeclassificationExemptionsApi {
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-classification-rest-api/src/main/java/org/alfresco/governance/classification/handler/DefaultClassificationValuesApiClient.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-classification-rest-api/src/main/java/org/alfresco/governance/classification/handler/DefaultClassificationValuesApiClient.java
@@ -18,6 +18,6 @@ package org.alfresco.governance.classification.handler;
 import org.springframework.cloud.openfeign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name = "alfrescoDefaultClassificationValuesApi", url = "${content.service.url}", path = "${governance.service.path}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfrescoDefaultClassificationValuesApi", url = "${content.service.url}", path = "${governance.service.path}", configuration = ClientConfiguration.class)
 public interface DefaultClassificationValuesApiClient extends DefaultClassificationValuesApi {
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-classification-rest-api/src/main/java/org/alfresco/governance/classification/handler/HighestChildClassificationApiClient.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-classification-rest-api/src/main/java/org/alfresco/governance/classification/handler/HighestChildClassificationApiClient.java
@@ -18,6 +18,6 @@ package org.alfresco.governance.classification.handler;
 import org.springframework.cloud.openfeign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name = "alfrescoHighestChildClassificationApi", url = "${content.service.url}", path = "${governance.service.path}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfrescoHighestChildClassificationApi", url = "${content.service.url}", path = "${governance.service.path}", configuration = ClientConfiguration.class)
 public interface HighestChildClassificationApiClient extends HighestChildClassificationApi {
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-classification-rest-api/src/main/java/org/alfresco/governance/classification/handler/SecuredNodesApiClient.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-classification-rest-api/src/main/java/org/alfresco/governance/classification/handler/SecuredNodesApiClient.java
@@ -18,6 +18,6 @@ package org.alfresco.governance.classification.handler;
 import org.springframework.cloud.openfeign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name = "alfrescoSecuredNodesApi", url = "${content.service.url}", path = "${governance.service.path}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfrescoSecuredNodesApi", url = "${content.service.url}", path = "${governance.service.path}", configuration = ClientConfiguration.class)
 public interface SecuredNodesApiClient extends SecuredNodesApi {
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-classification-rest-api/src/main/java/org/alfresco/governance/classification/handler/SecurityControlSettingsApiClient.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-classification-rest-api/src/main/java/org/alfresco/governance/classification/handler/SecurityControlSettingsApiClient.java
@@ -18,6 +18,6 @@ package org.alfresco.governance.classification.handler;
 import org.springframework.cloud.openfeign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name = "alfrescoSecurityControlSettingsApi", url = "${content.service.url}", path = "${governance.service.path}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfrescoSecurityControlSettingsApi", url = "${content.service.url}", path = "${governance.service.path}", configuration = ClientConfiguration.class)
 public interface SecurityControlSettingsApiClient extends SecurityControlSettingsApi {
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-classification-rest-api/src/main/java/org/alfresco/governance/classification/handler/SecurityGroupsApiClient.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-classification-rest-api/src/main/java/org/alfresco/governance/classification/handler/SecurityGroupsApiClient.java
@@ -18,6 +18,6 @@ package org.alfresco.governance.classification.handler;
 import org.springframework.cloud.openfeign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name = "alfrescoSecurityGroupsApi", url = "${content.service.url}", path = "${governance.service.path}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfrescoSecurityGroupsApi", url = "${content.service.url}", path = "${governance.service.path}", configuration = ClientConfiguration.class)
 public interface SecurityGroupsApiClient extends SecurityGroupsApi {
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-classification-rest-api/src/main/java/org/alfresco/governance/classification/handler/SecurityMarksApiClient.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-classification-rest-api/src/main/java/org/alfresco/governance/classification/handler/SecurityMarksApiClient.java
@@ -18,6 +18,6 @@ package org.alfresco.governance.classification.handler;
 import org.springframework.cloud.openfeign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name = "alfrescoSecurityMarksApi", url = "${content.service.url}", path = "${governance.service.path}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfrescoSecurityMarksApi", url = "${content.service.url}", path = "${governance.service.path}", configuration = ClientConfiguration.class)
 public interface SecurityMarksApiClient extends SecurityMarksApi {
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-core-rest-api/src/main/java/org/alfresco/governance/core/handler/FilePlansApiClient.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-core-rest-api/src/main/java/org/alfresco/governance/core/handler/FilePlansApiClient.java
@@ -18,6 +18,6 @@ package org.alfresco.governance.core.handler;
 import org.springframework.cloud.openfeign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name = "alfrescoFilePlansApi", url = "${content.service.url}", path = "${governance.service.path}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfrescoFilePlansApi", url = "${content.service.url}", path = "${governance.service.path}", configuration = ClientConfiguration.class)
 public interface FilePlansApiClient extends FilePlansApi {
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-core-rest-api/src/main/java/org/alfresco/governance/core/handler/FilesApiClient.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-core-rest-api/src/main/java/org/alfresco/governance/core/handler/FilesApiClient.java
@@ -18,6 +18,6 @@ package org.alfresco.governance.core.handler;
 import org.springframework.cloud.openfeign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name = "alfrescoFilesApi", url = "${content.service.url}", path = "${governance.service.path}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfrescoFilesApi", url = "${content.service.url}", path = "${governance.service.path}", configuration = ClientConfiguration.class)
 public interface FilesApiClient extends FilesApi {
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-core-rest-api/src/main/java/org/alfresco/governance/core/handler/GsSitesApiClient.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-core-rest-api/src/main/java/org/alfresco/governance/core/handler/GsSitesApiClient.java
@@ -18,6 +18,6 @@ package org.alfresco.governance.core.handler;
 import org.springframework.cloud.openfeign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name = "alfrescoGsSitesApi", url = "${content.service.url}", path = "${governance.service.path}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfrescoGsSitesApi", url = "${content.service.url}", path = "${governance.service.path}", configuration = ClientConfiguration.class)
 public interface GsSitesApiClient extends GsSitesApi {
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-core-rest-api/src/main/java/org/alfresco/governance/core/handler/RecordCategoriesApiClient.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-core-rest-api/src/main/java/org/alfresco/governance/core/handler/RecordCategoriesApiClient.java
@@ -18,6 +18,6 @@ package org.alfresco.governance.core.handler;
 import org.springframework.cloud.openfeign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name = "alfrescoRecordCategoriesApi", url = "${content.service.url}", path = "${governance.service.path}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfrescoRecordCategoriesApi", url = "${content.service.url}", path = "${governance.service.path}", configuration = ClientConfiguration.class)
 public interface RecordCategoriesApiClient extends RecordCategoriesApi {
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-core-rest-api/src/main/java/org/alfresco/governance/core/handler/RecordFoldersApiClient.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-core-rest-api/src/main/java/org/alfresco/governance/core/handler/RecordFoldersApiClient.java
@@ -18,6 +18,6 @@ package org.alfresco.governance.core.handler;
 import org.springframework.cloud.openfeign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name = "alfrescoRecordFoldersApi", url = "${content.service.url}", path = "${governance.service.path}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfrescoRecordFoldersApi", url = "${content.service.url}", path = "${governance.service.path}", configuration = ClientConfiguration.class)
 public interface RecordFoldersApiClient extends RecordFoldersApi {
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-core-rest-api/src/main/java/org/alfresco/governance/core/handler/RecordsApiClient.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-core-rest-api/src/main/java/org/alfresco/governance/core/handler/RecordsApiClient.java
@@ -18,6 +18,6 @@ package org.alfresco.governance.core.handler;
 import org.springframework.cloud.openfeign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name = "alfrescoRecordsApi", url = "${content.service.url}", path = "${governance.service.path}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfrescoRecordsApi", url = "${content.service.url}", path = "${governance.service.path}", configuration = ClientConfiguration.class)
 public interface RecordsApiClient extends RecordsApi {
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-core-rest-api/src/main/java/org/alfresco/governance/core/handler/TransferContainersApiClient.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-core-rest-api/src/main/java/org/alfresco/governance/core/handler/TransferContainersApiClient.java
@@ -18,6 +18,6 @@ package org.alfresco.governance.core.handler;
 import org.springframework.cloud.openfeign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name = "alfrescoTransferContainersApi", url = "${content.service.url}", path = "${governance.service.path}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfrescoTransferContainersApi", url = "${content.service.url}", path = "${governance.service.path}", configuration = ClientConfiguration.class)
 public interface TransferContainersApiClient extends TransferContainersApi {
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-core-rest-api/src/main/java/org/alfresco/governance/core/handler/TransfersApiClient.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-core-rest-api/src/main/java/org/alfresco/governance/core/handler/TransfersApiClient.java
@@ -18,6 +18,6 @@ package org.alfresco.governance.core.handler;
 import org.springframework.cloud.openfeign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name = "alfrescoTransfersApi", url = "${content.service.url}", path = "${governance.service.path}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfrescoTransfersApi", url = "${content.service.url}", path = "${governance.service.path}", configuration = ClientConfiguration.class)
 public interface TransfersApiClient extends TransfersApi {
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-core-rest-api/src/main/java/org/alfresco/governance/core/handler/UnfiledContainersApiClient.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-core-rest-api/src/main/java/org/alfresco/governance/core/handler/UnfiledContainersApiClient.java
@@ -18,6 +18,6 @@ package org.alfresco.governance.core.handler;
 import org.springframework.cloud.openfeign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name = "alfrescoUnfiledContainersApi", url = "${content.service.url}", path = "${governance.service.path}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfrescoUnfiledContainersApi", url = "${content.service.url}", path = "${governance.service.path}", configuration = ClientConfiguration.class)
 public interface UnfiledContainersApiClient extends UnfiledContainersApi {
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-core-rest-api/src/main/java/org/alfresco/governance/core/handler/UnfiledRecordFoldersApiClient.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-governance-core-rest-api/src/main/java/org/alfresco/governance/core/handler/UnfiledRecordFoldersApiClient.java
@@ -18,6 +18,6 @@ package org.alfresco.governance.core.handler;
 import org.springframework.cloud.openfeign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name = "alfrescoUnfiledRecordFoldersApi", url = "${content.service.url}", path = "${governance.service.path}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfrescoUnfiledRecordFoldersApi", url = "${content.service.url}", path = "${governance.service.path}", configuration = ClientConfiguration.class)
 public interface UnfiledRecordFoldersApiClient extends UnfiledRecordFoldersApi {
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-search-rest-api/src/main/java/org/alfresco/search/handler/SearchApiClient.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-search-rest-api/src/main/java/org/alfresco/search/handler/SearchApiClient.java
@@ -18,6 +18,6 @@ package org.alfresco.search.handler;
 import org.springframework.cloud.openfeign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name = "alfrescoSearchApi", url = "${content.service.url}", path = "${search.service.path}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfrescoSearchApi", url = "${content.service.url}", path = "${search.service.path}", configuration = ClientConfiguration.class)
 public interface SearchApiClient extends SearchApi {
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-search-sql-rest-api/src/main/java/org/alfresco/search/sql/handler/SqlApiClient.java
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-search-sql-rest-api/src/main/java/org/alfresco/search/sql/handler/SqlApiClient.java
@@ -18,6 +18,6 @@ package org.alfresco.search.sql.handler;
 import org.springframework.cloud.openfeign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name = "alfrescoSqlApi", url = "${content.service.url}", path = "${search-sql.service.path}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfrescoSqlApi", url = "${content.service.url}", path = "${search-sql.service.path}", configuration = ClientConfiguration.class)
 public interface SqlApiClient extends SqlApi {
 }

--- a/alfresco-java-rest-api/alfresco-java-rest-api-lib/src/main/resources/templates/libraries/spring-cloud/apiClient.mustache
+++ b/alfresco-java-rest-api/alfresco-java-rest-api-lib/src/main/resources/templates/libraries/spring-cloud/apiClient.mustache
@@ -4,7 +4,7 @@ import org.springframework.cloud.openfeign.FeignClient;
 import {{configPackage}}.ClientConfiguration;
 
 {{=<% %>=}}
-@FeignClient(name = "alfresco<%classname%>", url = "${<%title%>.url:<%hostWithoutBasePath%>}", configuration = ClientConfiguration.class, decode404 = true)
+@FeignClient(name = "alfresco<%classname%>", url = "${<%title%>.url:<%hostWithoutBasePath%>}", configuration = ClientConfiguration.class)
 <%={{ }}=%>
 public interface {{classname}}Client extends {{classname}} {
 }


### PR DESCRIPTION
Remove the option decode404 from the feign clients to be able to
handle 404 responses catching the corresponding exception.