### PR TITLE
AAE-6349 use workspace to avoid to regenerate clients for deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,7 @@ jobs:
       name: publish artifacts
       script: travis_wait $TRAVIS_WAIT_TIMEOUT mvn $MAVEN_CLI_OPTS deploy -DskipTests
       workspaces:
-        use:
-          name: generated-source
+        use: generated-source
 before_install:
   - |-
     export MAVEN_CLI_OPTS="${MAVEN_CLI_OPTS} -Ddoclint=none \

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
           paths:
             - alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib/generated
             - alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib/generated
-    - stage: post-test
+    - stage: publish
       name: publish artifacts
       script: travis_wait $TRAVIS_WAIT_TIMEOUT mvn $MAVEN_CLI_OPTS deploy -DskipTests
       workspaces:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,21 @@ import:
   - source: Alfresco/alfresco-build-tools:.travis.library.yml@v1.1.2
   - source: Alfresco/alfresco-build-tools:.travis.pre-commit.yml@v1.1.2
   - source: Alfresco/alfresco-process-scripts:slack_apa_channel_notification.yml@master
+jobs:
+  include:
+    - name: build application
+      stage: build
+      workspaces:
+        create:
+          name: generated-source
+          paths:
+            - alfresco-java-sdk/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib/generated
+            - alfresco-java-sdk/alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib/generated
+    - name: publish artifacts
+      stage: publish
+      workspaces:
+        use:
+          name: generated-source
 before_install:
   - |-
     export MAVEN_CLI_OPTS="${MAVEN_CLI_OPTS} -Ddoclint=none \

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 import:
   - source: Alfresco/alfresco-build-tools:.travis.library.yml@v1.1.2
+    mode: deep_merge
   - source: Alfresco/alfresco-build-tools:.travis.pre-commit.yml@v1.1.2
   - source: Alfresco/alfresco-process-scripts:slack_apa_channel_notification.yml@master
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ import:
 jobs:
   include:
     - stage: build
+      name: build application
       workspaces:
         create:
           name: generated-source
@@ -12,6 +13,7 @@ jobs:
             - alfresco-java-sdk/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib/generated
             - alfresco-java-sdk/alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib/generated
     - stage: publish
+      name: publish artifacts
       workspaces:
         use:
           name: generated-source

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,3 +28,4 @@ before_install:
   -  if [ "$TRAVIS_JOB_NAME" = "build application" ]; then (cd alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib; sh generate.sh); fi
 stages:
   - name: publish
+    if: type == pull_request

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,34 +4,6 @@ import:
   #- source: Alfresco/alfresco-build-tools:.travis.common.yml@v1.1.2
   - source: Alfresco/alfresco-build-tools:.travis.pre-commit.yml@v1.1.2
   - source: Alfresco/alfresco-process-scripts:slack_apa_channel_notification.yml@master
-jobs:
-  include:
-    - stage: build
-      name: build application
-      script: travis_wait $TRAVIS_WAIT_TIMEOUT mvn $MAVEN_CLI_OPTS verify -Dlogging.root.level=off -Dspring.main.banner-mode=off
-      workspaces:
-        create:
-          name: generated-source
-          paths:
-            - alfresco-java-sdk/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib/generated
-            - alfresco-java-sdk/alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib/generated
-    - stage: publish
-      name: publish artifacts
-      script: travis_wait $TRAVIS_WAIT_TIMEOUT mvn $MAVEN_CLI_OPTS deploy -DskipTests
-      workspaces:
-        use:
-          name: generated-source
-before_install:
-  - |-
-    export MAVEN_CLI_OPTS="${MAVEN_CLI_OPTS} -Ddoclint=none \
-      -DaltReleaseDeploymentRepository=alfresco-public::default::https://artifacts.alfresco.com/nexus/content/repositories/releases \
-      -DaltSnapshotDeploymentRepository=alfresco-public-snapshots::default::https://artifacts.alfresco.com/nexus/content/repositories/snapshots
-      -Denvironment.host=${ENVIRONMENT_HOST:-apadev.envalfresco.com}
-      -Denvironment.application.name=${ENVIRONMENT_APP:-simpleapp}
-      -Dags.version=${AGS_VERSION:-14.9}
-      -Dacs.version=${ACS_VERSION:-7.1.0.1}"
-  -  if [ "$TRAVIS_JOB_NAME" = "build application" ]; then (cd alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib; sh generate.sh); fi
-  -  if [ "$TRAVIS_JOB_NAME" = "build application" ]; then (cd alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib; sh generate.sh); fi
 language: shell
 env:
   global:
@@ -67,3 +39,31 @@ stages:
     if: type != pull_request
   - name: post-trigger
     if: type != pull_request
+jobs:
+  include:
+    - stage: build
+      name: build application
+      script: travis_wait $TRAVIS_WAIT_TIMEOUT mvn $MAVEN_CLI_OPTS verify -Dlogging.root.level=off -Dspring.main.banner-mode=off
+      workspaces:
+        create:
+          name: generated-source
+          paths:
+            - alfresco-java-sdk/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib/generated
+            - alfresco-java-sdk/alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib/generated
+    - stage: publish
+      name: publish artifacts
+      script: travis_wait $TRAVIS_WAIT_TIMEOUT mvn $MAVEN_CLI_OPTS deploy -DskipTests
+      workspaces:
+        use:
+          name: generated-source
+before_install:
+  - |-
+    export MAVEN_CLI_OPTS="${MAVEN_CLI_OPTS} -Ddoclint=none \
+      -DaltReleaseDeploymentRepository=alfresco-public::default::https://artifacts.alfresco.com/nexus/content/repositories/releases \
+      -DaltSnapshotDeploymentRepository=alfresco-public-snapshots::default::https://artifacts.alfresco.com/nexus/content/repositories/snapshots
+      -Denvironment.host=${ENVIRONMENT_HOST:-apadev.envalfresco.com}
+      -Denvironment.application.name=${ENVIRONMENT_APP:-simpleapp}
+      -Dags.version=${AGS_VERSION:-14.9}
+      -Dacs.version=${ACS_VERSION:-7.1.0.1}"
+  -  if [ "$TRAVIS_JOB_NAME" = "build application" ]; then (cd alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib; sh generate.sh); fi
+  -  if [ "$TRAVIS_JOB_NAME" = "build application" ]; then (cd alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib; sh generate.sh); fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,44 +1,10 @@
 import:
   - source: Alfresco/alfresco-build-tools:.travis.maven_config.yml@v1.1.2
   - source: Alfresco/alfresco-build-tools:.travis.java_config.yml@v1.1.2
-  #- source: Alfresco/alfresco-build-tools:.travis.common.yml@v1.1.2
+  - source: Alfresco/alfresco-build-tools:.travis.common.yml@v1.1.2
+    mode: deep_merge_prepend
   - source: Alfresco/alfresco-build-tools:.travis.pre-commit.yml@v1.1.2
   - source: Alfresco/alfresco-process-scripts:slack_apa_channel_notification.yml@master
-language: shell
-env:
-  global:
-    - TRAVIS_WAIT_TIMEOUT=${TRAVIS_WAIT_TIMEOUT:-30}
-    - BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-${TRAVIS_BRANCH}}
-branches:
-  only:
-    - develop
-stages:
-  - name: pre-lint
-  - name: lint
-  - name: post-lint
-  - name: pre-build
-  - name: build
-  - name: post-build
-  - name: pre-test
-  - name: test
-  - name: post-test
-  - name: pre-publish
-    if: type != pull_request
-  - name: publish
-  - name: post-publish
-    if: type != pull_request
-  - name: pre-deploy
-    if: type != pull_request
-  - name: deploy
-    if: type != pull_request
-  - name: post-deploy
-    if: type != pull_request
-  - name: pre-trigger
-    if: type != pull_request
-  - name: trigger
-    if: type != pull_request
-  - name: post-trigger
-    if: type != pull_request
 jobs:
   include:
     - stage: build
@@ -67,3 +33,6 @@ before_install:
       -Dacs.version=${ACS_VERSION:-7.1.0.1}"
   -  if [ "$TRAVIS_JOB_NAME" = "build application" ]; then (cd alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib; sh generate.sh); fi
   -  if [ "$TRAVIS_JOB_NAME" = "build application" ]; then (cd alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib; sh generate.sh); fi
+stages:
+  - name: publish
+    if: type == pull_request

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 import:
-  - source: Alfresco/alfresco-build-tools:.travis.library.yml@v1.1.2
+  - source: Alfresco/alfresco-build-tools:.travis.maven_config.yml@v1.1.2
+  - source: Alfresco/alfresco-build-tools:.travis.java_config.yml@v1.1.2
+  - source: Alfresco/alfresco-build-tools:.travis.common.yml@v1.1.2
   - source: Alfresco/alfresco-build-tools:.travis.pre-commit.yml@v1.1.2
   - source: Alfresco/alfresco-process-scripts:slack_apa_channel_notification.yml@master
 jobs:
   include:
     - stage: build
       name: build application
+      script: travis_wait $TRAVIS_WAIT_TIMEOUT mvn $MAVEN_CLI_OPTS verify -Dlogging.root.level=off -Dspring.main.banner-mode=off
       workspaces:
         create:
           name: generated-source
@@ -14,6 +17,7 @@ jobs:
             - alfresco-java-sdk/alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib/generated
     - stage: publish
       name: publish artifacts
+      script: travis_wait $TRAVIS_WAIT_TIMEOUT mvn $MAVEN_CLI_OPTS deploy -DskipTests
       workspaces:
         use:
           name: generated-source
@@ -28,6 +32,3 @@ before_install:
       -Dacs.version=${ACS_VERSION:-7.1.0.1}"
   -  if [ "$TRAVIS_JOB_NAME" = "build application" ]; then (cd alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib; sh generate.sh); fi
   -  if [ "$TRAVIS_JOB_NAME" = "build application" ]; then (cd alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib; sh generate.sh); fi
-stages:
-  - name: publish
-    if: type == pull_request

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ jobs:
         create:
           name: generated-source
           paths:
-            - alfresco-java-sdk/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib/generated
-            - alfresco-java-sdk/alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib/generated
+            - alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib/generated
+            - alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib/generated
     - stage: post-test
       name: publish artifacts
       script: travis_wait $TRAVIS_WAIT_TIMEOUT mvn $MAVEN_CLI_OPTS deploy -DskipTests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 import:
   - source: Alfresco/alfresco-build-tools:.travis.maven_config.yml@v1.1.2
   - source: Alfresco/alfresco-build-tools:.travis.java_config.yml@v1.1.2
-  - source: Alfresco/alfresco-build-tools:.travis.common.yml@v1.1.2
+  #- source: Alfresco/alfresco-build-tools:.travis.common.yml@v1.1.2
   - source: Alfresco/alfresco-build-tools:.travis.pre-commit.yml@v1.1.2
   - source: Alfresco/alfresco-process-scripts:slack_apa_channel_notification.yml@master
 jobs:
@@ -32,3 +32,38 @@ before_install:
       -Dacs.version=${ACS_VERSION:-7.1.0.1}"
   -  if [ "$TRAVIS_JOB_NAME" = "build application" ]; then (cd alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib; sh generate.sh); fi
   -  if [ "$TRAVIS_JOB_NAME" = "build application" ]; then (cd alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib; sh generate.sh); fi
+language: shell
+env:
+  global:
+    - TRAVIS_WAIT_TIMEOUT=${TRAVIS_WAIT_TIMEOUT:-30}
+    - BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-${TRAVIS_BRANCH}}
+branches:
+  only:
+    - develop
+stages:
+  - name: pre-lint
+  - name: lint
+  - name: post-lint
+  - name: pre-build
+  - name: build
+  - name: post-build
+  - name: pre-test
+  - name: test
+  - name: post-test
+  - name: pre-publish
+    if: type != pull_request
+  - name: publish
+  - name: post-publish
+    if: type != pull_request
+  - name: pre-deploy
+    if: type != pull_request
+  - name: deploy
+    if: type != pull_request
+  - name: post-deploy
+    if: type != pull_request
+  - name: pre-trigger
+    if: type != pull_request
+  - name: trigger
+    if: type != pull_request
+  - name: post-trigger
+    if: type != pull_request

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,17 @@
 import:
   - source: Alfresco/alfresco-build-tools:.travis.library.yml@v1.1.2
-    mode: merge
   - source: Alfresco/alfresco-build-tools:.travis.pre-commit.yml@v1.1.2
   - source: Alfresco/alfresco-process-scripts:slack_apa_channel_notification.yml@master
 jobs:
   include:
-    - name: build application
-      stage: build
+    - stage: build
       workspaces:
         create:
           name: generated-source
           paths:
             - alfresco-java-sdk/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib/generated
             - alfresco-java-sdk/alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib/generated
-    - name: publish artifacts
-      stage: publish
+    - stage: publish
       workspaces:
         use:
           name: generated-source
@@ -29,3 +26,5 @@ before_install:
       -Dacs.version=${ACS_VERSION:-7.1.0.1}"
   -  if [ "$TRAVIS_JOB_NAME" = "build application" ]; then (cd alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib; sh generate.sh); fi
   -  if [ "$TRAVIS_JOB_NAME" = "build application" ]; then (cd alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib; sh generate.sh); fi
+stages:
+  - name: publish

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 import:
   - source: Alfresco/alfresco-build-tools:.travis.library.yml@v1.1.2
-    mode: deep_merge
+    mode: merge
   - source: Alfresco/alfresco-build-tools:.travis.pre-commit.yml@v1.1.2
   - source: Alfresco/alfresco-process-scripts:slack_apa_channel_notification.yml@master
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ import:
   - source: Alfresco/alfresco-build-tools:.travis.maven_config.yml@v1.1.2
   - source: Alfresco/alfresco-build-tools:.travis.java_config.yml@v1.1.2
   - source: Alfresco/alfresco-build-tools:.travis.common.yml@v1.1.2
-    mode: deep_merge_prepend
   - source: Alfresco/alfresco-build-tools:.travis.pre-commit.yml@v1.1.2
   - source: Alfresco/alfresco-process-scripts:slack_apa_channel_notification.yml@master
 jobs:
@@ -16,7 +15,7 @@ jobs:
           paths:
             - alfresco-java-sdk/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib/generated
             - alfresco-java-sdk/alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib/generated
-    - stage: publish
+    - stage: post-test
       name: publish artifacts
       script: travis_wait $TRAVIS_WAIT_TIMEOUT mvn $MAVEN_CLI_OPTS deploy -DskipTests
       workspaces:
@@ -33,6 +32,3 @@ before_install:
       -Dacs.version=${ACS_VERSION:-7.1.0.1}"
   -  if [ "$TRAVIS_JOB_NAME" = "build application" ]; then (cd alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib; sh generate.sh); fi
   -  if [ "$TRAVIS_JOB_NAME" = "build application" ]; then (cd alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib; sh generate.sh); fi
-stages:
-  - name: publish
-    if: type == pull_request


### PR DESCRIPTION
On the develop branch, the publish job is failing because Travis deletes the disk in each step.
With this PR I'm adding a workspace to share the generated code between jobs.
Unfortunately, I have to duplicate some code from Alfresco/alfresco-build-tools:.travis.library.yml@v1.1.2 because the Travis import mode doesn't allow to extend items in a list.