### PR TITLE
REPO-5699 Include ACS Model API to alfresco-java-sdk

### DIFF
--- a/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib/patch.sh
+++ b/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib/patch.sh
@@ -4,7 +4,7 @@ set -e
 GENERATED_SOURCE_DIR=${GENERATED_SOURCE_DIR:-generated}
 case $(uname | tr '[:upper:]' '[:lower:]') in
   darwin*)
-    export EDIT_FILE_IN_PLACE_PARAM="''"
+    export EDIT_FILE_IN_PLACE_PARAM="\'\'"
     ;;
   *)
     export EDIT_FILE_IN_PLACE_PARAM=

--- a/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib/patch.sh
+++ b/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib/patch.sh
@@ -49,12 +49,21 @@ find "${GENERATED_SOURCE_DIR}" -type f -name 'NodeBody*.java' -exec sed \
   -e 's;putPropertiesItem(String key, String propertiesItem);putPropertiesItem(String key, Object propertiesItem);g' \
   -i $EDIT_FILE_IN_PLACE_PARAM {} +
 
-
 find ${GENERATED_SOURCE_DIR} -type f -iname 'ModelsApi.java' -exec sed \
   -e 's/ResponseEntity<Void> getModelContent/byte[] getModelContent/' \
   -e 's/ResponseEntity<Void> exportModel/byte[] exportModel/' \
   -e 's/ResponseEntity<String>/byte[]/' \
   -e 's/@RequestParam("file")/@PathVariable("file")/' \
+  -i $EDIT_FILE_IN_PLACE_PARAM {} +
+
+find ${GENERATED_SOURCE_DIR} -type f -name 'Type.java' -exec sed \
+  -e 's/public class Type/public class Type extends AbstractClass/' \
+  -e '14,49d' \
+  -i $EDIT_FILE_IN_PLACE_PARAM {} +
+
+find ${GENERATED_SOURCE_DIR} -type f -name 'Aspect.java' -exec sed \
+  -e 's/public class Aspect/public class Aspect extends AbstractClass/' \
+  -e '14,49d' \
   -i $EDIT_FILE_IN_PLACE_PARAM {} +
 
 find ${GENERATED_SOURCE_DIR} -type f -name 'SearchApiClient.java' -exec sed \

--- a/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib/pom.xml
+++ b/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib/pom.xml
@@ -28,6 +28,7 @@
     <acs.discovery.api>${project.build.directory}/definitions/alfresco-discovery.yaml</acs.discovery.api>
     <acs.governance-core.api>${project.build.directory}/definitions/gs-core-api.yaml</acs.governance-core.api>
     <acs.governance-classification.api>${project.build.directory}/definitions/gs-classification-api.yaml</acs.governance-classification.api>
+    <acs.model.api>${project.build.directory}/definitions/alfresco-model.yaml</acs.model.api>
     <acs.search.api>${project.build.directory}/definitions/alfresco-search.yaml</acs.search.api>
     <acs.search-sql.api>${project.build.directory}/definitions/alfresco-search-sql.yaml</acs.search-sql.api>
 
@@ -41,6 +42,7 @@
     <module>${project.build.generatedSourceDirectory}/alfresco-discovery-rest-api</module>
     <module>${project.build.generatedSourceDirectory}/alfresco-governance-core-rest-api</module>
     <module>${project.build.generatedSourceDirectory}/alfresco-governance-classification-rest-api</module>
+    <module>${project.build.generatedSourceDirectory}/alfresco-model-rest-api</module>
     <module>${project.build.generatedSourceDirectory}/alfresco-search-rest-api</module>
     <module>${project.build.generatedSourceDirectory}/alfresco-search-sql-rest-api</module>
     <module>alfresco-event-gateway-api-client</module>
@@ -292,6 +294,40 @@
                     <apiPackage>${project.groupId}.governance.classification.handler</apiPackage>
                     <modelPackage>${project.groupId}.governance.classification.model</modelPackage>
                     <invokerPackage>${project.groupId}</invokerPackage>
+                  </configOptions>
+                </configuration>
+              </execution>
+              <execution>
+                <id>generate-model-api-documentation</id>
+                <goals>
+                  <goal>generate</goal>
+                </goals>
+                <configuration>
+                  <language>java</language>
+                  <library>resttemplate</library>
+                  <inputSpec>${acs.model.api}</inputSpec>
+                  <output>${project.build.generatedSourceDirectory}/alfresco-model-rest-api</output>
+                  <artifactId>alfresco-model-rest-api</artifactId>
+                  <configOptions>
+                    <apiPackage>${project.groupId}.model.handler</apiPackage>
+                    <modelPackage>${project.groupId}.model.model</modelPackage>
+                    <invokerPackage>${project.groupId}.model</invokerPackage>
+                  </configOptions>
+                </configuration>
+              </execution>
+              <execution>
+                <id>generate-model-api</id>
+                <goals>
+                  <goal>generate</goal>
+                </goals>
+                <configuration>
+                  <inputSpec>${acs.model.api}</inputSpec>
+                  <output>${project.build.generatedSourceDirectory}/alfresco-model-rest-api</output>
+                  <artifactId>alfresco-model-rest-api</artifactId>
+                  <configOptions>
+                    <apiPackage>${project.groupId}.model.handler</apiPackage>
+                    <modelPackage>${project.groupId}.model.model</modelPackage>
+                    <invokerPackage>${project.groupId}.model</invokerPackage>
                   </configOptions>
                 </configuration>
               </execution>

--- a/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-spring-boot/pom.xml
+++ b/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-spring-boot/pom.xml
@@ -54,6 +54,11 @@
     </dependency>
     <dependency>
       <groupId>org.alfresco</groupId>
+      <artifactId>alfresco-model-rest-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.alfresco</groupId>
       <artifactId>alfresco-search-rest-api</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-spring-boot/src/main/java/org/alfresco/rest/sdk/config/AlfrescoRestApiAutoConfiguration.java
+++ b/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-spring-boot/src/main/java/org/alfresco/rest/sdk/config/AlfrescoRestApiAutoConfiguration.java
@@ -26,6 +26,7 @@ import org.springframework.context.annotation.PropertySource;
     "org.alfresco.discovery.handler",
     "org.alfresco.governance.core.handler",
     "org.alfresco.governance.classification.handler",
+    "org.alfresco.model.handler",
     "org.alfresco.search.handler",
     "org.alfresco.search.sql.handler"
 })

--- a/alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib/patch.sh
+++ b/alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib/patch.sh
@@ -4,7 +4,7 @@ set -e
 GENERATED_SOURCE_DIR=${GENERATED_SOURCE_DIR:-generated}
 case $(uname | tr '[:upper:]' '[:lower:]') in
   darwin*)
-    export EDIT_FILE_IN_PLACE_PARAM="''"
+    export EDIT_FILE_IN_PLACE_PARAM="\'\'"
     ;;
   *)
     export EDIT_FILE_IN_PLACE_PARAM=

--- a/samples/extension-template/README.md
+++ b/samples/extension-template/README.md
@@ -5,8 +5,8 @@ Sample application to demonstrate both event handling and REST API usage within 
 It is a Spring Boot application that makes use of:
 * [Alfresco Java Event API Spring Boot Starter](../../alfresco-java-event-api/README.md#spring-boot-custom-starter)
 to define a sample [```EventHandler```](../../alfresco-java-event-api/alfresco-java-event-api-handling/src/main/java/org/alfresco/event/sdk/handling/handler/EventHandler.java)
-* [Alfresco Java REST API Spring Boot Starter](../../alfresco-java-rest-api)
-  to consume [Alfresco Respository Core API](../../alfresco-java-rest-api/alfresco-java-rest-api-lib/generated/alfresco-core-rest-api)
+* [Alfresco Java ACS REST API Spring Boot Starter](../../alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-spring-boot-starter)
+  to consume Alfresco Repository Core API and Alfresco Repository Model API.
 
 ## Usage
 

--- a/samples/extension-template/src/main/java/org/alfresco/sdk/sample/handler/HtmlContentCreatedHandler.java
+++ b/samples/extension-template/src/main/java/org/alfresco/sdk/sample/handler/HtmlContentCreatedHandler.java
@@ -27,6 +27,8 @@ import org.alfresco.event.sdk.model.v1.model.DataAttributes;
 import org.alfresco.event.sdk.model.v1.model.NodeResource;
 import org.alfresco.event.sdk.model.v1.model.RepoEvent;
 import org.alfresco.event.sdk.model.v1.model.Resource;
+import org.alfresco.model.handler.TypesApi;
+import org.alfresco.model.model.Type;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,10 +45,11 @@ public class HtmlContentCreatedHandler implements OnNodeCreatedEventHandler {
 
     @Autowired
     NodesApi nodesApi;
+    @Autowired
+    TypesApi typesApi;
 
     @Value("${local.storage.folder}")
     String localStorageFolder;
-
 
     @Override
     public void handleEvent(final RepoEvent<DataAttributes<Resource>> repoEvent) {
@@ -54,6 +57,8 @@ public class HtmlContentCreatedHandler implements OnNodeCreatedEventHandler {
         final NodeResource nodeResource = (NodeResource) repoEvent.getData().getResource();
 
         LOGGER.info("An HTML content named {} has been created!", nodeResource.getName());
+
+        logNodeTypeInformation(nodeResource);
 
         try {
 
@@ -87,5 +92,18 @@ public class HtmlContentCreatedHandler implements OnNodeCreatedEventHandler {
     public EventFilter getEventFilter() {
         return IsFileFilter.get()
             .and(MimeTypeFilter.of("text/html"));
+    }
+
+    private void logNodeTypeInformation(final NodeResource nodeResource) {
+        String nodeType = nodesApi.getNode(nodeResource.getId(), null, null, null)
+            .getBody()
+            .getEntry()
+            .getNodeType();
+
+        Type type = typesApi.getType(nodeType)
+            .getBody()
+            .getEntry();
+
+        LOGGER.info("The type of the content is {} from the model {}", type.getDescription(), type.getModel().getDescription());
     }
 }


### PR DESCRIPTION
Include the new Model API [Alfresco Content Services REST API Explorer](https://api-explorer.alfresco.com/api-explorer/?urls.primaryName=Model%20API)
As a new auto-generated library of alfresco-java-sdk.

Fixes #73 