### PR TITLE
ISSUE-119 Change parent for samples module

### DIFF
--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -5,9 +5,10 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.alfresco</groupId>
-    <artifactId>alfresco-java-sdk</artifactId>
-    <version>5.1.5-SNAPSHOT</version>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.4.2</version>
+    <relativePath/>
   </parent>
 
   <artifactId>alfresco-java-sdk-samples</artifactId>


### PR DESCRIPTION
Change the parent for the samples maven module to be the Spring Boot
starter project instead of the SDK, since this dependency is not
required and forced the integrator to add license headers.