### PR TITLE
ISSUE-119 Setup artifact version for samples project

### DIFF
--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -12,6 +12,7 @@
   </parent>
 
   <artifactId>alfresco-java-sdk-samples</artifactId>
+  <version>5.1.5-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Alfresco :: Java SDK :: Samples</name>
   <description>Sample application of the Java SDK</description>


### PR DESCRIPTION
Because we changed the parent of this maven module from Alfresco Java SDK
main project to the spring boot parent dependency we need now to setup the
version number of the module explicitly.