### PR TITLE
AAE-21915 ignore versions above 17 for amazon corretto image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,4 +15,4 @@ updates:
       interval: "daily"
     ignore:
       - dependency-name: "amazoncorretto"
-        versions: [">21"]
+        versions: [">17"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,10 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "amazoncorretto"
+        versions: [">21"]


### PR DESCRIPTION
The purpose of this pr is to prevent amazoncorretto from being updated to versions after 17


https://hyland.atlassian.net/browse/AAE-21915