### PR TITLE
[PRODSEC-10314]: CVE-2025-48976 fix by common-fileupload bump

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,11 @@
         <artifactId>acs-event-model</artifactId>
         <version>${acs-event-model.version}</version>
       </dependency>
+      <dependency>
+        <groupId>commons-fileupload</groupId>
+        <artifactId>commons-fileupload</artifactId>
+        <version>${common-fileupload.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -121,6 +126,7 @@
     <argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
     <spring-cloud.version>2024.0.1</spring-cloud.version>
     <swagger-core.version>1.5.20</swagger-core.version>
+    <common-fileupload.version>1.6.0</common-fileupload.version>
     <license-maven-plugin.version>3.0</license-maven-plugin.version>
     <third-party-license-maven-plugin.version>2.0.1</third-party-license-maven-plugin.version>
     <acs-event-model.version>1.0.2</acs-event-model.version>


### PR DESCRIPTION
Updated commons-fileupload to 1.6.0 to resolve CVE-2025-48976 – see https://nvd.nist.gov/vuln/detail/CVE-2025-48976
