### PR TITLE
Upgrade Spring Boot and Cloud to allow the SDK to be used with Spring AI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.5.3</version>
+    <version>3.5.4</version>
     <relativePath />
   </parent>
   <groupId>org.alfresco</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.4.7</version>
+    <version>3.5.3</version>
     <relativePath />
   </parent>
   <groupId>org.alfresco</groupId>
@@ -137,7 +137,7 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <maven.compiler.release>${java.release}</maven.compiler.release>
     <argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
-    <spring-cloud.version>2024.0.1</spring-cloud.version>
+    <spring-cloud.version>2025.0.0</spring-cloud.version>
     <swagger-core.version>1.5.20</swagger-core.version>
     <common-fileupload.version>1.6.0</common-fileupload.version>
     <license-maven-plugin.version>3.0</license-maven-plugin.version>


### PR DESCRIPTION
In order to use the alfresco-java-sdk with Spring AI we need to upgrade both the Spring Boot and Cloud dependencies