### PR TITLE
[PRODSEC-10611]: Bump commons-lang3 to 3.20.0 to address CVE-2025-48924

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,11 @@
         <artifactId>nimbus-jose-jwt</artifactId>
         <version>${com.nimbusds.outh2.sdk.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>${org.apache.common-lang-3.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -160,6 +165,7 @@
     <third-party-license-maven-plugin.version>2.0.1</third-party-license-maven-plugin.version>
     <acs-event-model.version>1.0.2</acs-event-model.version>
     <com.nimbusds.outh2.sdk.version>10.5</com.nimbusds.outh2.sdk.version>
+    <org.apache.common-lang-3.version>3.20.0</org.apache.common-lang-3.version>
   </properties>
   <repositories>
     <repository>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -33,7 +33,7 @@
 
   <dependencies>
     <!--
-      commons-lang3 is required here, as it does not get inherited from the parent pom, and it directly using spring boot 3.5.7
+      commons-lang3 is required here, as it does not get inherited from the parent pom, and it is directly using spring boot 3.5.7
       which is fetching commons-lang 3.17.0, while the SDK and samples need at least 3.20.0 to avoid CVE-2025-48924
     -->
     <dependency>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -16,6 +16,10 @@
   <name>Alfresco :: Java SDK :: Samples</name>
   <description>Sample application of the Java SDK</description>
 
+  <properties>
+    <org.apache.common-lang-3.version>3.20.0</org.apache.common-lang-3.version>
+  </properties>
+
   <distributionManagement>
     <repository>
       <id>alfresco-enterprise-releases</id>
@@ -26,6 +30,14 @@
       <url>https://artifacts.alfresco.com/nexus/content/repositories/enterprise-snapshots</url>
     </snapshotRepository>
   </distributionManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>${org.apache.common-lang-3.version}</version>
+    </dependency>
+  </dependencies>
 
   <modules>
     <module>extension-template</module>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -32,6 +32,10 @@
   </distributionManagement>
 
   <dependencies>
+    <!--
+      commons-lang3 is required here, as it does not get inherited from the parent pom, and it directly using spring boot 3.5.7
+      which is fetching commons-lang 3.17.0, while the SDK and samples need at least 3.20.0 to avoid CVE-2025-48924
+    -->
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>


### PR DESCRIPTION
Jira: https://hyland.atlassian.net/browse/PRODSEC-10611

This pull request adds the `commons-lang3` library from Apache Commons to both the main project and the sample application. The changes ensure that the library is available as a dependency and that its version is managed via Maven properties.

**Dependency management:**

* Added `commons-lang3` as a dependency in the main `pom.xml`, with its version controlled by the new property `org.apache.common-lang-3.version`.
* Introduced the `org.apache.common-lang-3.version` property in the main `pom.xml` to specify the version (`3.20.0`) of the new dependency.

**Sample application updates:**

* Added the `org.apache.common-lang-3.version` property to `samples/pom.xml` for consistent version management.
* Included `commons-lang3` as a dependency in the sample application's `pom.xml`, using the defined property for its version.