### PR TITLE
Added an sdk-release Maven profile with the Sonatype Central..

### DIFF
--- a/.ci.settings.xml
+++ b/.ci.settings.xml
@@ -24,18 +24,18 @@
     </server>
     <server>
       <id>alfresco-internal-releases</id>
-      <username>${MAVEN_USERNAME}</username>
-      <password>${MAVEN_PASSWORD}</password>
+      <username>${env.MAVEN_USERNAME}</username>
+      <password>${env.MAVEN_PASSWORD}</password>
     </server>
     <server>
       <id>alfresco-enterprise-snapshots</id>
-      <username>${MAVEN_USERNAME}</username>
-      <password>${MAVEN_PASSWORD}</password>
+      <username>${env.MAVEN_USERNAME}</username>
+      <password>${env.MAVEN_PASSWORD}</password>
     </server>
     <server>
       <id>alfresco-enterprise-releases</id>
-      <username>${MAVEN_USERNAME}</username>
-      <password>${MAVEN_PASSWORD}</password>
+      <username>${env.MAVEN_USERNAME}</username>
+      <password>${env.MAVEN_PASSWORD}</password>
     </server>
   </servers>
 </settings>

--- a/.ci.settings.xml
+++ b/.ci.settings.xml
@@ -18,6 +18,11 @@
       <password>${env.MAVEN_PASSWORD}</password>
     </server>
     <server>
+      <id>central</id>
+      <username>${env.MAVEN_CENTRAL_USERNAME}</username>
+      <password>${env.MAVEN_CENTRAL_PASSWORD}</password>
+    </server>
+    <server>
       <id>alfresco-internal-releases</id>
       <username>${MAVEN_USERNAME}</username>
       <password>${MAVEN_PASSWORD}</password>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,20 +20,12 @@ on:
   workflow_dispatch:
 
 env:
-  MAVEN_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
-  MAVEN_USERNAME: ${{ secrets.NEXUS_USERNAME }}
-  MAVEN_CENTRAL_USERNAME: ${{ secrets.OSS_SONATYPE_USERNAME }}
-  MAVEN_CENTRAL_PASSWORD: ${{ secrets.OSS_SONATYPE_PASSWORD }}
   GITHUB_ACTIONS_DEPLOY_TIMEOUT: 60
 #  CONTENT_SERVICE_SECURITY_BASICAUTH_PASSWORD: ${{ secrets.CONTENT_SERVICE_SECURITY_BASICAUTH_PASSWORD }}
 #  CONTENT_SERVICE_SECURITY_BASICAUTH_USERNAME: ${{ secrets.CONTENT_SERVICE_SECURITY_BASICAUTH_USERNAME }}
 #  CONTENT_SERVICE_URL: ${{ secrets.CONTENT_SERVICE_URL }}
   AGS_VERSION: 26.2.0.28
   ACS_VERSION: 26.2.0-A.2
-  QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
-  QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
-  DOCKERHUB_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-  DOCKERHUB_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
   GITHUB_EVENT: ${{ github.event_name }}
   BRANCH_NAME: ${{ github.ref_name }}
 
@@ -66,6 +58,8 @@ jobs:
     needs:
       - pre-commit
     env:
+      MAVEN_USERNAME: ${{ secrets.NEXUS_USERNAME }}
+      MAVEN_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
       MAVEN_CLI_OPTS: >
         source:jar -B -q -e -fae -V -DinstallAtEnd=true -U -Ddoclint=none
         -Dags.version=${AGS_VERSION}
@@ -93,6 +87,9 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build_and_verify
+    env:
+      MAVEN_USERNAME: ${{ secrets.NEXUS_USERNAME }}
+      MAVEN_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
     if: >
       !(failure() || cancelled()) &&
       (github.ref_name == 'develop' || startsWith(github.ref_name, 'release/')) &&
@@ -157,6 +154,8 @@ jobs:
     needs:
       - release
     env:
+      MAVEN_USERNAME: ${{ secrets.NEXUS_USERNAME }}
+      MAVEN_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
       MAVEN_CLI_OPTS: >
         source:jar -B -q -e -fae -V -DinstallAtEnd=true -U -Ddoclint=none
         -DaltReleaseDeploymentRepository=alfresco-public::default::https://artifacts.alfresco.com/nexus/content/repositories/releases
@@ -183,17 +182,22 @@ jobs:
       - release
       - check_version
     env:
-      GPG_SIGNING_PASSPHRASE: ${{ secrets.GPG_SIGNING_PASSPHRASE }}
+      MAVEN_USERNAME: ${{ secrets.NEXUS_USERNAME }}
+      MAVEN_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
     steps:
       - uses: actions/checkout@v4
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v15.7.1
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v15.7.1
       - name: "Set up Maven Central credentials"
+        env:
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.OSS_SONATYPE_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.OSS_SONATYPE_PASSWORD }}
         run: |
           mkdir -p ~/.m2
-          cp .ci.settings.xml ~/.m2/settings.xml
+          envsubst < .ci.settings.xml > ~/.m2/settings.xml
       - name: "Import GPG key"
         env:
+          GPG_SIGNING_PASSPHRASE: ${{ secrets.GPG_SIGNING_PASSPHRASE }}
           GPG_TTY: $(tty)
         run: |
           echo "${{ secrets.GPG_SIGNING_PRIVATE_KEY }}" | gpg --batch --import
@@ -202,6 +206,8 @@ jobs:
           echo "allow-loopback-pinentry" >> ~/.gnupg/gpg-agent.conf
           gpg --batch --yes --pinentry-mode loopback --passphrase $GPG_SIGNING_PASSPHRASE --list-keys
       - name: "Publish to Maven Central"
+        env:
+          GPG_SIGNING_PASSPHRASE: ${{ secrets.GPG_SIGNING_PASSPHRASE }}
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: |
           mvn --batch-mode clean package gpg:sign central-publishing:publish -P sdk-release -DskipTests=true -Dgpg.passphrase=$GPG_SIGNING_PASSPHRASE

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       github.ref_name == 'develop' ||
       github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v15.7.1
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v15.7.1
       - name: "Clean-up SNAPSHOT artifacts"
@@ -65,7 +65,7 @@ jobs:
         -Dags.version=${AGS_VERSION}
         -Dacs.version=${ACS_VERSION}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v15.7.1
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v15.7.1
       - name: "Build"
@@ -97,7 +97,7 @@ jobs:
       github.event_name != 'pull_request' &&
       contains(github.event.head_commit.message, '[release]')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v15.7.1
@@ -129,7 +129,7 @@ jobs:
     outputs:
       is_ga: ${{ steps.publish_version.outputs.is_ga }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v15.7.1
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v15.7.1
       - name: "Check version"
@@ -163,7 +163,7 @@ jobs:
         -Dags.version=${AGS_VERSION}
         -Dacs.version=${ACS_VERSION}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v15.7.1
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v15.7.1
       - name: "Publish artifacts"
@@ -185,13 +185,10 @@ jobs:
       MAVEN_USERNAME: ${{ secrets.NEXUS_USERNAME }}
       MAVEN_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v15.7.1
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v15.7.1
       - name: "Set up Maven Central credentials"
-        env:
-          MAVEN_CENTRAL_USERNAME: ${{ secrets.OSS_SONATYPE_USERNAME }}
-          MAVEN_CENTRAL_PASSWORD: ${{ secrets.OSS_SONATYPE_PASSWORD }}
         run: |
           mkdir -p ~/.m2
           envsubst < .ci.settings.xml > ~/.m2/settings.xml
@@ -207,6 +204,8 @@ jobs:
           gpg --batch --yes --pinentry-mode loopback --passphrase $GPG_SIGNING_PASSPHRASE --list-keys
       - name: "Publish to Maven Central"
         env:
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.OSS_SONATYPE_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.OSS_SONATYPE_PASSWORD }}
           GPG_SIGNING_PASSPHRASE: ${{ secrets.GPG_SIGNING_PASSPHRASE }}
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ on:
 env:
   MAVEN_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
   MAVEN_USERNAME: ${{ secrets.NEXUS_USERNAME }}
+  MAVEN_CENTRAL_USERNAME: ${{ secrets.OSS_SONATYPE_USERNAME }}
+  MAVEN_CENTRAL_PASSWORD: ${{ secrets.OSS_SONATYPE_PASSWORD }}
   GITHUB_ACTIONS_DEPLOY_TIMEOUT: 60
 #  CONTENT_SERVICE_SECURITY_BASICAUTH_PASSWORD: ${{ secrets.CONTENT_SERVICE_SECURITY_BASICAUTH_PASSWORD }}
 #  CONTENT_SERVICE_SECURITY_BASICAUTH_USERNAME: ${{ secrets.CONTENT_SERVICE_SECURITY_BASICAUTH_USERNAME }}
@@ -120,6 +122,31 @@ jobs:
           bash ./scripts/ci/verify_release_tag.sh
           bash ./scripts/ci/maven_release.sh
 
+  check_version:
+    name: "Check version"
+    runs-on: ubuntu-latest
+    needs:
+      - release
+    if: >
+      contains(github.event.head_commit.message, '[publish]')
+    outputs:
+      is_ga: ${{ steps.publish_version.outputs.is_ga }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v15.7.1
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v15.7.1
+      - name: "Check version"
+        id: publish_version
+        run: |
+          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "is_ga=true" >> $GITHUB_OUTPUT
+            echo "GA version detected: $VERSION"
+          else
+            echo "is_ga=false" >> $GITHUB_OUTPUT
+            echo "Non GA version detected: $VERSION"
+          fi
+
   publish:
     name: "Publish"
     runs-on: ubuntu-latest
@@ -143,3 +170,38 @@ jobs:
       - name: "Publish artifacts"
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: mvn deploy $MAVEN_CLI_OPTS -DskipTests=true
+
+  publish_to_maven_central:
+    name: "Publish to Maven Central"
+    runs-on: ubuntu-latest
+    if: >
+      (github.ref_name == 'develop' || startsWith(github.ref_name, 'release/')) &&
+      contains(github.event.head_commit.message, '[publish]') &&
+      github.event_name != 'pull_request' &&
+      needs.check_version.outputs.is_ga == 'true'
+    needs:
+      - release
+      - check_version
+    env:
+      GPG_SIGNING_PASSPHRASE: ${{ secrets.GPG_SIGNING_PASSPHRASE }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v15.7.1
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v15.7.1
+      - name: "Set up Maven Central credentials"
+        run: |
+          mkdir -p ~/.m2
+          cp .ci.settings.xml ~/.m2/settings.xml
+      - name: "Import GPG key"
+        env:
+          GPG_TTY: $(tty)
+        run: |
+          echo "${{ secrets.GPG_SIGNING_PRIVATE_KEY }}" | gpg --batch --import
+          echo "use-agent" >> ~/.gnupg/gpg.conf
+          echo "pinentry-mode loopback" >> ~/.gnupg/gpg.conf
+          echo "allow-loopback-pinentry" >> ~/.gnupg/gpg-agent.conf
+          gpg --batch --yes --pinentry-mode loopback --passphrase $GPG_SIGNING_PASSPHRASE --list-keys
+      - name: "Publish to Maven Central"
+        timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
+        run: |
+          mvn --batch-mode clean package gpg:sign central-publishing:publish -P sdk-release -DskipTests=true -Dgpg.passphrase=$GPG_SIGNING_PASSPHRASE

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,10 +188,10 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v15.7.1
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v15.7.1
-      - name: "Set up Maven Central credentials"
+      - name: "Install Maven settings"
         run: |
           mkdir -p ~/.m2
-          envsubst < .ci.settings.xml > ~/.m2/settings.xml
+          cp .ci.settings.xml ~/.m2/settings.xml
       - name: "Import GPG key"
         env:
           GPG_SIGNING_PASSPHRASE: ${{ secrets.GPG_SIGNING_PASSPHRASE }}

--- a/pom.xml
+++ b/pom.xml
@@ -324,4 +324,58 @@ limitations under the License.]]>
 	  </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>sdk-release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.10.0</version>
+            <extensions>true</extensions>
+            <configuration>
+              <publishingServerId>central</publishingServerId>
+              <autoPublish>true</autoPublish>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>3.4.0</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>3.2.8</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+                <configuration>
+                  <gpgArguments>
+                    <arg>--pinentry-mode</arg>
+                    <arg>loopback</arg>
+                  </gpgArguments>
+                  <passphrase>${gpg.passphrase}</passphrase>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
..publishing plugin plus source and GPG signing, added Central credentials to the CI settings template, and added workflow logic to gate Central publication to GA versions only and publish them to Maven Central after the existing release job.