### PR TITLE
PRODSEC-11860 - Bump org.bouncycastle:bcprov-jdk18on:jar to 1.84

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,11 @@
         <artifactId>activemq-client</artifactId>
         <version>${activemq-client.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcprov-jdk18on</artifactId>
+		<version>${dependency.bouncycastle.version}</version> 
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -177,6 +182,7 @@
     <org.apache.common-lang-3.version>3.20.0</org.apache.common-lang-3.version>
     <dependency.spring-security-web.version>7.0.4</dependency.spring-security-web.version>
     <activemq-client.version>6.2.5</activemq-client.version>
+	<dependency.bouncycastle.version>1.84</dependency.bouncycastle.version>
   </properties>
   <repositories>
     <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
       <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcprov-jdk18on</artifactId>
-		<version>${dependency.bouncycastle.version}</version> 
+        <version>${dependency.bouncycastle.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
     <org.apache.common-lang-3.version>3.20.0</org.apache.common-lang-3.version>
     <dependency.spring-security-web.version>7.0.4</dependency.spring-security-web.version>
     <activemq-client.version>6.2.5</activemq-client.version>
-	<dependency.bouncycastle.version>1.84</dependency.bouncycastle.version>
+    <dependency.bouncycastle.version>1.84</dependency.bouncycastle.version>
   </properties>
   <repositories>
     <repository>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -38,7 +38,7 @@
       <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcprov-jdk18on</artifactId>
-        <version>${dependency.bouncycastle.version}</version> 
+        <version>${dependency.bouncycastle.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -20,7 +20,7 @@
     <org.apache.common-lang-3.version>3.20.0</org.apache.common-lang-3.version>
     <dependency.spring-security-web.version>7.0.4</dependency.spring-security-web.version>
     <activemq-client.version>6.2.5</activemq-client.version>
-	<dependency.bouncycastle.version>1.84</dependency.bouncycastle.version>
+    <dependency.bouncycastle.version>1.84</dependency.bouncycastle.version>
   </properties>
 
   <dependencyManagement>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -20,6 +20,7 @@
     <org.apache.common-lang-3.version>3.20.0</org.apache.common-lang-3.version>
     <dependency.spring-security-web.version>7.0.4</dependency.spring-security-web.version>
     <activemq-client.version>6.2.5</activemq-client.version>
+	<dependency.bouncycastle.version>1.84</dependency.bouncycastle.version>
   </properties>
 
   <dependencyManagement>
@@ -33,6 +34,11 @@
         <groupId>org.apache.activemq</groupId>
         <artifactId>activemq-client</artifactId>
         <version>${activemq-client.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcprov-jdk18on</artifactId>
+        <version>${dependency.bouncycastle.version}</version> 
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
org.bouncycastle:bcprov-jdk18on:jar version  1.81 detected as a transitive dependencies in the various modules of Java SDK. 
Since it is a transitive dependency , so in those modules - no direct reference of org.bouncycastle:bcprov-jdk18on:jar was present.
Upon analysis we have figured out that all those modules either inherits parent pom.xml or  samples/pom.xml. Henceforth , new non-vurnenable vesion - **1.84** has been referenced both in the pom files as a new dependency and that actually overrides vulnerable version  in the impacted modules.