### PR TITLE
Bumped spring-boot-starter-parent from 4.0.5 → 4.0.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>4.0.5</version>
+    <version>4.0.6</version>
     <relativePath />
   </parent>
   <groupId>org.alfresco</groupId>


### PR DESCRIPTION
This resolves the vulnerable spring-boot-security:4.0.5 pulled transitively via: alfresco-java-rest-api-common → spring-boot-starter-security-oauth2-client:4.0.5 → spring-boot-security:4.0.5