### PR TITLE
fix: Upgrade Tomcat to 11.0.22 to resolve critical CVEs

### DIFF
--- a/samples/oauth2-feign-sample/pom.xml
+++ b/samples/oauth2-feign-sample/pom.xml
@@ -39,8 +39,8 @@
           <groupId>org.springframework</groupId>
           <artifactId>spring-webmvc</artifactId>
         </exclusion>
-        <!-- Exclude Tomcat 11.0.21 to fix CVE-2026-41293, CVE-2026-43512, CVE-2026-43515,
-             CVE-2026-41284, CVE-2026-43513, CVE-2026-42498, CVE-2026-43514 -->
+        <!-- Exclude transitive Tomcat embed artifacts so they can be pinned explicitly below (fixes CVE-2026-41293, CVE-2026-43512, CVE-2026-43515,
+             CVE-2026-41284, CVE-2026-43513, CVE-2026-42498, CVE-2026-43514) -->
         <exclusion>
           <groupId>org.apache.tomcat.embed</groupId>
           <artifactId>tomcat-embed-core</artifactId>

--- a/samples/oauth2-feign-sample/pom.xml
+++ b/samples/oauth2-feign-sample/pom.xml
@@ -16,7 +16,9 @@
     <spring-cloud.version>2025.1.1</spring-cloud.version>
     <dependency.spring-security-web.version>7.0.5</dependency.spring-security-web.version>
     <dependency.spring-webmvc.version>7.0.7</dependency.spring-webmvc.version>
-    <!-- Fix CVE-2026-41293, CVE-2026-43512, CVE-2026-43515, CVE-2026-41284, CVE-2026-43513, CVE-2026-42498, CVE-2026-43514 -->
+    <!-- Override Tomcat to 11.0.22 to fix CVE-2026-41293, CVE-2026-43512, CVE-2026-43515,
+         CVE-2026-41284, CVE-2026-43513, CVE-2026-42498, CVE-2026-43514.
+         See: https://tomcat.apache.org/security-11.html#Fixed_in_Apache_Tomcat_11.0.22 -->
     <tomcat.version>11.0.22</tomcat.version>
   </properties>
 

--- a/samples/oauth2-feign-sample/pom.xml
+++ b/samples/oauth2-feign-sample/pom.xml
@@ -16,6 +16,8 @@
     <spring-cloud.version>2025.1.1</spring-cloud.version>
     <dependency.spring-security-web.version>7.0.5</dependency.spring-security-web.version>
     <dependency.spring-webmvc.version>7.0.7</dependency.spring-webmvc.version>
+    <!-- Fix CVE-2026-41293, CVE-2026-43512, CVE-2026-43515, CVE-2026-41284, CVE-2026-43513, CVE-2026-42498, CVE-2026-43514 -->
+    <tomcat.version>11.0.22</tomcat.version>
   </properties>
 
   <dependencyManagement>
@@ -39,50 +41,7 @@
           <groupId>org.springframework</groupId>
           <artifactId>spring-webmvc</artifactId>
         </exclusion>
-        <!-- Exclude transitive Tomcat embed artifacts so they can be pinned explicitly below (fixes CVE-2026-41293, CVE-2026-43512, CVE-2026-43515,
-             CVE-2026-41284, CVE-2026-43513, CVE-2026-42498, CVE-2026-43514) -->
-        <exclusion>
-          <groupId>org.apache.tomcat.embed</groupId>
-          <artifactId>tomcat-embed-core</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.tomcat.embed</groupId>
-          <artifactId>tomcat-embed-el</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.tomcat.embed</groupId>
-          <artifactId>tomcat-embed-websocket</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.tomcat</groupId>
-          <artifactId>tomcat-annotations-api</artifactId>
-        </exclusion>
       </exclusions>
-    </dependency>
-    <!--
-      Tomcat 11.0.22: fixes CVE-2026-41293, CVE-2026-43512, CVE-2026-43515,
-      CVE-2026-41284, CVE-2026-43513, CVE-2026-42498, CVE-2026-43514.
-      tomcat-annotations-api upgraded for version consistency.
-    -->
-    <dependency>
-      <groupId>org.apache.tomcat.embed</groupId>
-      <artifactId>tomcat-embed-core</artifactId>
-      <version>11.0.22</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.tomcat.embed</groupId>
-      <artifactId>tomcat-embed-el</artifactId>
-      <version>11.0.22</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.tomcat.embed</groupId>
-      <artifactId>tomcat-embed-websocket</artifactId>
-      <version>11.0.22</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.tomcat</groupId>
-      <artifactId>tomcat-annotations-api</artifactId>
-      <version>11.0.22</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>

--- a/samples/oauth2-feign-sample/pom.xml
+++ b/samples/oauth2-feign-sample/pom.xml
@@ -39,7 +39,50 @@
           <groupId>org.springframework</groupId>
           <artifactId>spring-webmvc</artifactId>
         </exclusion>
+        <!-- Exclude Tomcat 11.0.21 to fix CVE-2026-41293, CVE-2026-43512, CVE-2026-43515,
+             CVE-2026-41284, CVE-2026-43513, CVE-2026-42498, CVE-2026-43514 -->
+        <exclusion>
+          <groupId>org.apache.tomcat.embed</groupId>
+          <artifactId>tomcat-embed-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.tomcat.embed</groupId>
+          <artifactId>tomcat-embed-el</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.tomcat.embed</groupId>
+          <artifactId>tomcat-embed-websocket</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.tomcat</groupId>
+          <artifactId>tomcat-annotations-api</artifactId>
+        </exclusion>
       </exclusions>
+    </dependency>
+    <!--
+      Tomcat 11.0.22: fixes CVE-2026-41293, CVE-2026-43512, CVE-2026-43515,
+      CVE-2026-41284, CVE-2026-43513, CVE-2026-42498, CVE-2026-43514.
+      tomcat-annotations-api upgraded for version consistency.
+    -->
+    <dependency>
+      <groupId>org.apache.tomcat.embed</groupId>
+      <artifactId>tomcat-embed-core</artifactId>
+      <version>11.0.22</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.tomcat.embed</groupId>
+      <artifactId>tomcat-embed-el</artifactId>
+      <version>11.0.22</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.tomcat.embed</groupId>
+      <artifactId>tomcat-embed-websocket</artifactId>
+      <version>11.0.22</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.tomcat</groupId>
+      <artifactId>tomcat-annotations-api</artifactId>
+      <version>11.0.22</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>


### PR DESCRIPTION
### Summary
Override Tomcat version to 11.0.22 in the `oauth2-feign-sample` module to address 7 known vulnerabilities in Tomcat 11.0.21.

### CVEs Resolved

| CVE | Severity | Description |
|-----|----------|-------------|
| CVE-2026-41293 | Critical | HTTP/2 request headers not validated |
| CVE-2026-43512 | Critical | Digest auth authenticates unknown users with password "null" |
| CVE-2026-43515 | Critical | Security constraints not correctly applied |
| CVE-2026-41284 | High | Unbounded read in WebDAV LOCK/PROPFIND |
| CVE-2026-43513 | High | LockOutRealm case-sensitivity bypass |
| CVE-2026-42498 | High | WebSocket auth header exposure on redirect |
| CVE-2026-43514 | Low | AJP secret timing attack |

### Changes
- Added `<tomcat.version>11.0.22</tomcat.version>` property to override Spring Boot's managed Tomcat version.

### Testing
- Verified dependency tree resolves all Tomcat artifacts to 11.0.22.
- No code changes required; backward compatible patch upgrade.

**Reference :** https://docs.spring.io/spring-boot/appendix/dependency-versions/properties.html
