### PR TITLE
Added "-Dmaven.deploy.skip=true" to maven_release.sh

### DIFF
--- a/scripts/ci/maven_release.sh
+++ b/scripts/ci/maven_release.sh
@@ -12,7 +12,7 @@ git pull
 
 # Run the release plugin - with "[skip ci]" in the release commit message
 mvn -B \
-    "-Darguments=-DskipTests -DbuildNumber=$GITHUB_RUN_NUMBER" \
+    "-Darguments=-DskipTests -DbuildNumber=$GITHUB_RUN_NUMBER -Dmaven.deploy.skip=true" \
     release:clean release:prepare release:perform \
     -DscmCommentPrefix="[maven-release-plugin][skip ci] " \
     -Dusername="${GIT_USERNAME}" \


### PR DESCRIPTION
Added maven.deploy.skip=true to the release:perform arguments so deployment is handled exclusively by the dedicated publish job.  This tells release:perform's internal mvn deploy invocation to skip actual artifact upload, so only the publish job (which runs after release) will deploy to Nexus.