### PR TITLE
[release] Alfresco OOP SDK Alpha 7.3.4-A.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,3 +334,7 @@ The default values for the ACS environment used for integration tests are:
 - `CONTENT_SERVICE_URL` - `http://localhost:8080`
 - `CONTENT_SERVICE_SECURITY_BASICAUTH_USERNAME` - `admin`
 - `CONTENT_SERVICE_SECURITY_BASICAUTH_PASSWORD` - `admin`
+
+## Releasing the Java SDK
+
+See [docs/release-process.md](docs/release-process.md) for the automated release process (Nexus, verified commits, tags, and Maven Central publishing).

--- a/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib/alfresco-event-gateway-api-client/pom.xml
+++ b/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib/alfresco-event-gateway-api-client/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>org.alfresco</groupId>
     <artifactId>alfresco-acs-java-rest-api-lib</artifactId>
-    <version>7.3.4-SNAPSHOT</version>
+    <version>7.3.4-A.1-SNAPSHOT</version>
   </parent>
   <artifactId>alfresco-event-gateway-api-client</artifactId>
   <name>alfresco-event-gateway-api</name>
   <description>Client library for the Alfresco Event Gateway API.</description>
-  <version>7.3.4-SNAPSHOT</version>
+  <version>7.3.4-A.1-SNAPSHOT</version>
   <dependencies>
     <dependency>
       <groupId>io.swagger</groupId>

--- a/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib/generated/alfresco-auth-rest-api/pom.xml
+++ b/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib/generated/alfresco-auth-rest-api/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>org.alfresco</groupId>
     <artifactId>alfresco-acs-java-rest-api-lib</artifactId>
-    <version>7.3.4-SNAPSHOT</version>
+    <version>7.3.4-A.1-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
   <artifactId>alfresco-auth-rest-api</artifactId>
   <name>alfresco-auth-rest-api</name>
-  <version>7.3.4-SNAPSHOT</version>
+  <version>7.3.4-A.1-SNAPSHOT</version>
   <dependencies>
     <dependency>
       <groupId>io.swagger</groupId>

--- a/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib/generated/alfresco-core-rest-api/pom.xml
+++ b/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib/generated/alfresco-core-rest-api/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>org.alfresco</groupId>
     <artifactId>alfresco-acs-java-rest-api-lib</artifactId>
-    <version>7.3.4-SNAPSHOT</version>
+    <version>7.3.4-A.1-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
   <artifactId>alfresco-core-rest-api</artifactId>
   <name>alfresco-core-rest-api</name>
-  <version>7.3.4-SNAPSHOT</version>
+  <version>7.3.4-A.1-SNAPSHOT</version>
   <dependencies>
     <dependency>
       <groupId>io.swagger</groupId>

--- a/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib/generated/alfresco-discovery-rest-api/pom.xml
+++ b/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib/generated/alfresco-discovery-rest-api/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>org.alfresco</groupId>
     <artifactId>alfresco-acs-java-rest-api-lib</artifactId>
-    <version>7.3.4-SNAPSHOT</version>
+    <version>7.3.4-A.1-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
   <artifactId>alfresco-discovery-rest-api</artifactId>
   <name>alfresco-discovery-rest-api</name>
-  <version>7.3.4-SNAPSHOT</version>
+  <version>7.3.4-A.1-SNAPSHOT</version>
   <dependencies>
     <dependency>
       <groupId>io.swagger</groupId>

--- a/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib/generated/alfresco-governance-classification-rest-api/pom.xml
+++ b/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib/generated/alfresco-governance-classification-rest-api/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>org.alfresco</groupId>
     <artifactId>alfresco-acs-java-rest-api-lib</artifactId>
-    <version>7.3.4-SNAPSHOT</version>
+    <version>7.3.4-A.1-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
   <artifactId>alfresco-governance-classification-rest-api</artifactId>
   <name>alfresco-governance-classification-rest-api</name>
-  <version>7.3.4-SNAPSHOT</version>
+  <version>7.3.4-A.1-SNAPSHOT</version>
   <dependencies>
     <dependency>
       <groupId>io.swagger</groupId>

--- a/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib/generated/alfresco-governance-core-rest-api/pom.xml
+++ b/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib/generated/alfresco-governance-core-rest-api/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>org.alfresco</groupId>
     <artifactId>alfresco-acs-java-rest-api-lib</artifactId>
-    <version>7.3.4-SNAPSHOT</version>
+    <version>7.3.4-A.1-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
   <artifactId>alfresco-governance-core-rest-api</artifactId>
   <name>alfresco-governance-core-rest-api</name>
-  <version>7.3.4-SNAPSHOT</version>
+  <version>7.3.4-A.1-SNAPSHOT</version>
   <dependencies>
     <dependency>
       <groupId>io.swagger</groupId>

--- a/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib/generated/alfresco-model-rest-api/pom.xml
+++ b/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib/generated/alfresco-model-rest-api/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>org.alfresco</groupId>
     <artifactId>alfresco-acs-java-rest-api-lib</artifactId>
-    <version>7.3.4-SNAPSHOT</version>
+    <version>7.3.4-A.1-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
   <artifactId>alfresco-model-rest-api</artifactId>
   <name>alfresco-model-rest-api</name>
-  <version>7.3.4-SNAPSHOT</version>
+  <version>7.3.4-A.1-SNAPSHOT</version>
   <dependencies>
     <dependency>
       <groupId>io.swagger</groupId>

--- a/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib/generated/alfresco-search-rest-api/pom.xml
+++ b/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib/generated/alfresco-search-rest-api/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>org.alfresco</groupId>
     <artifactId>alfresco-acs-java-rest-api-lib</artifactId>
-    <version>7.3.4-SNAPSHOT</version>
+    <version>7.3.4-A.1-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
   <artifactId>alfresco-search-rest-api</artifactId>
   <name>alfresco-search-rest-api</name>
-  <version>7.3.4-SNAPSHOT</version>
+  <version>7.3.4-A.1-SNAPSHOT</version>
   <dependencies>
     <dependency>
       <groupId>io.swagger</groupId>

--- a/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib/generated/alfresco-search-sql-rest-api/pom.xml
+++ b/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib/generated/alfresco-search-sql-rest-api/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>org.alfresco</groupId>
     <artifactId>alfresco-acs-java-rest-api-lib</artifactId>
-    <version>7.3.4-SNAPSHOT</version>
+    <version>7.3.4-A.1-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
   <artifactId>alfresco-search-sql-rest-api</artifactId>
   <name>alfresco-search-sql-rest-api</name>
-  <version>7.3.4-SNAPSHOT</version>
+  <version>7.3.4-A.1-SNAPSHOT</version>
   <dependencies>
     <dependency>
       <groupId>io.swagger</groupId>

--- a/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib/pom.xml
+++ b/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.alfresco</groupId>
     <artifactId>alfresco-acs-java-rest-api</artifactId>
-    <version>7.3.4-SNAPSHOT</version>
+    <version>7.3.4-A.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>alfresco-acs-java-rest-api-lib</artifactId>

--- a/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-spring-boot-starter/pom.xml
+++ b/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.alfresco</groupId>
     <artifactId>alfresco-acs-java-rest-api</artifactId>
-    <version>7.3.4-SNAPSHOT</version>
+    <version>7.3.4-A.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>alfresco-acs-java-rest-api-spring-boot-starter</artifactId>

--- a/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-spring-boot/pom.xml
+++ b/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-spring-boot/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.alfresco</groupId>
     <artifactId>alfresco-acs-java-rest-api</artifactId>
-    <version>7.3.4-SNAPSHOT</version>
+    <version>7.3.4-A.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>alfresco-acs-java-rest-api-spring-boot</artifactId>

--- a/alfresco-acs-java-rest-api/pom.xml
+++ b/alfresco-acs-java-rest-api/pom.xml
@@ -4,7 +4,7 @@
 
   <parent>
     <groupId>org.alfresco</groupId>
-    <version>7.3.4-SNAPSHOT</version>
+    <version>7.3.4-A.1-SNAPSHOT</version>
     <artifactId>alfresco-java-sdk</artifactId>
   </parent>
 

--- a/alfresco-java-event-api/alfresco-java-event-api-handling/pom.xml
+++ b/alfresco-java-event-api/alfresco-java-event-api-handling/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.alfresco</groupId>
     <artifactId>alfresco-java-event-api</artifactId>
-    <version>7.3.4-SNAPSHOT</version>
+    <version>7.3.4-A.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>alfresco-java-event-api-handling</artifactId>

--- a/alfresco-java-event-api/alfresco-java-event-api-integration/pom.xml
+++ b/alfresco-java-event-api/alfresco-java-event-api-integration/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.alfresco</groupId>
     <artifactId>alfresco-java-event-api</artifactId>
-    <version>7.3.4-SNAPSHOT</version>
+    <version>7.3.4-A.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>alfresco-java-event-api-integration</artifactId>

--- a/alfresco-java-event-api/alfresco-java-event-api-spring-boot-starter/pom.xml
+++ b/alfresco-java-event-api/alfresco-java-event-api-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.alfresco</groupId>
     <artifactId>alfresco-java-event-api</artifactId>
-    <version>7.3.4-SNAPSHOT</version>
+    <version>7.3.4-A.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>alfresco-java-event-api-spring-boot-starter</artifactId>

--- a/alfresco-java-event-api/alfresco-java-event-api-spring-boot/pom.xml
+++ b/alfresco-java-event-api/alfresco-java-event-api-spring-boot/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.alfresco</groupId>
     <artifactId>alfresco-java-event-api</artifactId>
-    <version>7.3.4-SNAPSHOT</version>
+    <version>7.3.4-A.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>alfresco-java-event-api-spring-boot</artifactId>

--- a/alfresco-java-event-api/pom.xml
+++ b/alfresco-java-event-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.alfresco</groupId>
     <artifactId>alfresco-java-sdk</artifactId>
-    <version>7.3.4-SNAPSHOT</version>
+    <version>7.3.4-A.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>alfresco-java-event-api</artifactId>

--- a/alfresco-java-rest-api-common/pom.xml
+++ b/alfresco-java-rest-api-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.alfresco</groupId>
     <artifactId>alfresco-java-sdk</artifactId>
-    <version>7.3.4-SNAPSHOT</version>
+    <version>7.3.4-A.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>alfresco-java-rest-api-common</artifactId>

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,180 @@
+# Alfresco Java SDK release process
+
+This document describes how to release the Alfresco Java SDK using the automated CI pipeline introduced in [ACS-12085](https://hyland.atlassian.net/browse/ACS-12085).
+
+Releases are performed on **`develop`** or **`release/**`** via GitHub Actions. The pipeline uses [`maven-release-slim`](https://github.com/Alfresco/alfresco-build-tools) from Alfresco build-tools and a GitHub App installation token to create **verified** commits and tags.
+
+## Version conventions
+
+### Alpha versions (dot notation)
+
+Alpha releases **must** use a dot between `A` and the alpha number:
+
+| Correct | Incorrect |
+|---------|-----------|
+| `7.3.4-A.1` | `7.3.4-A1` |
+| `7.3.4-A.2` | `7.3.4-A2` |
+
+Use this format in `RELEASE_VERSION`, Git tags, and released Maven coordinates. **Do not** include `-SNAPSHOT` in `RELEASE_VERSION`.
+
+### Pre-release POM versions (`-SNAPSHOT`)
+
+Before triggering `[release]`, all project `pom.xml` files **must** use the alpha version **with** the `-SNAPSHOT` suffix:
+
+| `RELEASE_VERSION` (in `ci.yml`) | POM version (before release) |
+|---------------------------------|------------------------------|
+| `7.3.4-A.1` | `7.3.4-A.1-SNAPSHOT` |
+| `7.3.4` (GA) | `7.3.4-SNAPSHOT` |
+
+This matches the convention used in previous releases (for example [PR #425](https://github.com/Alfresco/alfresco-java-sdk/pull/425): `7.3.3-SNAPSHOT` → `7.3.3-A.1-SNAPSHOT`).
+
+### Next development version (`-SNAPSHOT`)
+
+`DEVELOPMENT_VERSION` **must** include the `-SNAPSHOT` suffix. This is the version written to all POMs after the release completes.
+
+| Correct | Incorrect |
+|---------|-----------|
+| `7.3.4-A.2-SNAPSHOT` | `7.3.4-A.2` |
+| `7.3.5-SNAPSHOT` | `7.3.5` |
+
+This applies to both alpha and GA release cycles.
+
+## Overview
+
+| Step | Trigger | CI job | Result |
+|------|---------|--------|--------|
+| Alpha / Nexus release | `[release]` in commit message | `release` | Deploy to Alfresco Nexus, Git tag, verified bot commits |
+| GA Maven Central publish | `[publish]` in commit message | `publish_to_maven_central` | Publish to Maven Central (GA versions only) |
+| Re-publish to Maven Central | `workflow_dispatch` with `publish_to_maven_central` | `publish_to_maven_central` | Re-run publish for an existing tag |
+
+Alpha releases (for example `7.3.4-A.1`) are deployed to **Nexus only**. GA releases (for example `7.3.4`) can additionally be published to **Maven Central** using `[publish]`.
+
+## Prerequisites
+
+- Merge your changes to **`develop`** or a **`release/**`** branch.
+- Ensure CI tests pass (`build_and_verify` job). Do not use `[skip tests]` on a release commit.
+- Confirm the repository has the `GH_APP_ENGINEERING_CONTRIB_CLIENT_ID` variable and `GH_APP_ENGINEERING_CONTRIB_PRIVATE_KEY` secret configured (DevOps).
+- Protected branches must allow verified commits from the engineering-contrib GitHub App.
+
+## Configure release versions
+
+Version numbers are configured in the workflow `env` block in [`.github/workflows/ci.yml`](../.github/workflows/ci.yml):
+
+```yaml
+RELEASE_VERSION: "7.3.4-A.1" # The version of the release (tag).
+DEVELOPMENT_VERSION: "7.3.4-A.2-SNAPSHOT" # The version that will be set in pom files after the release (next dev version).
+```
+
+| Variable | Purpose | Example (alpha) | Example (GA) |
+|----------|---------|-----------------|--------------|
+| `RELEASE_VERSION` | Version to release and tag | `7.3.4-A.1` | `7.3.4` |
+| `DEVELOPMENT_VERSION` | Next development version written to POMs after release (must end with `-SNAPSHOT`) | `7.3.4-A.2-SNAPSHOT` | `7.3.5-SNAPSHOT` |
+
+Update both values in the **same commit** that triggers the release. The GitHub App bot does **not** modify `ci.yml`; you must update it again before the next release.
+
+## Alpha release (Nexus)
+
+Example: release `7.3.4-A.1` when preparing the next alpha cycle.
+
+1. Update `RELEASE_VERSION` and `DEVELOPMENT_VERSION` in [`.github/workflows/ci.yml`](../.github/workflows/ci.yml):
+
+   ```yaml
+   RELEASE_VERSION: "7.3.4-A.1"
+   DEVELOPMENT_VERSION: "7.3.4-A.2-SNAPSHOT"
+   ```
+
+2. Update all project `pom.xml` files to `${RELEASE_VERSION}-SNAPSHOT` (for example `7.3.4-A.1-SNAPSHOT`).
+
+3. Commit and push to **`develop`** (or `release/**`) with `[release]` in the commit message, for example:
+
+   ```text
+   [release] Alfresco Java SDK 7.3.4-A.1 alpha
+   ```
+
+4. Wait for the CI workflow to finish. The `release` job runs only when:
+   - `build_and_verify` succeeds
+   - The branch is `develop` or `release/**`
+   - The commit message contains `[release]`
+   - The commit message does **not** contain `[no release]`
+
+### What happens automatically
+
+When the `release` job succeeds, CI will:
+
+1. Set all POM versions to `RELEASE_VERSION`
+2. Deploy artifacts to Alfresco Nexus
+3. Create a **verified** bot commit for the release version
+4. Create a Git tag named exactly `RELEASE_VERSION` (for example `7.3.4-A.1`)
+5. Set all POM versions to `DEVELOPMENT_VERSION`
+6. Create a **verified** bot commit for the next development version
+
+You should **not** manually create Git tags. The bot commits for the release and post-release POM versions are created automatically.
+
+### After an alpha release
+
+On `develop` you should see:
+
+- Git tag: `7.3.4-A.1` (plain version string from `RELEASE_VERSION`)
+- Two new **Verified** commits from the engineering-contrib bot
+- Root POM version: `7.3.4-A.2-SNAPSHOT`
+- Artifacts on Alfresco Nexus for `7.3.4-A.1`
+
+Before the next alpha, update `ci.yml` again (for example `7.3.4-A.2` / `7.3.4-A.3-SNAPSHOT`).
+
+## GA release and Maven Central
+
+For a GA release (version matching `major.minor.patch` with no suffix):
+
+1. Update `RELEASE_VERSION` and `DEVELOPMENT_VERSION` in `ci.yml`, for example:
+
+   ```yaml
+   RELEASE_VERSION: "7.3.4"
+   DEVELOPMENT_VERSION: "7.3.5-SNAPSHOT"
+   ```
+
+2. Update all project `pom.xml` files to `${RELEASE_VERSION}-SNAPSHOT` (for example `7.3.4-SNAPSHOT`).
+
+3. Push to **`develop`** with both keywords in the **same** commit message:
+
+   ```text
+   [release][publish] Alfresco Java SDK 7.3.4
+   ```
+
+   To publish to Maven Central as part of the GA release, include `[publish]` in the **same** commit message as `[release]` so the workflow checks out the tagged `RELEASE_VERSION`.
+
+   A standalone `[publish]` commit (without `[release]` in the same workflow run) will not have `needs.release.outputs.release_tag` set, so Maven Central publish will not target the released tag.
+
+### Re-publish to Maven Central
+
+If the publish step failed after a successful release, use **workflow_dispatch**:
+
+1. Open the CI workflow in GitHub Actions.
+2. Run workflow manually with:
+   - `publish_to_maven_central`: `true`
+   - `release_tag`: the existing tag (for example `7.3.4`)
+
+## Commit message keywords
+
+| Keyword | Effect |
+|---------|--------|
+| `[release]` | Run the automated Nexus release |
+| `[publish]` | Run Maven Central publish (checkout uses release tag from the same workflow run) |
+| `[no release]` | Skip the release job even if `[release]` would otherwise match |
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---------|----------------|
+| Release job skipped | No `[release]` in commit message, wrong branch, or `build_and_verify` failed |
+| App token step fails | GitHub App credentials not configured on the repository |
+| Verified commit rejected | Branch protection or App permissions |
+| Tag already exists | `RELEASE_VERSION` was released before |
+| Maven Central publish failed | Missing `[publish]` on same commit as `[release]`, or use `workflow_dispatch` with `release_tag` |
+
+## Related files
+
+- [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) — CI pipeline and release version configuration
+- [Alfresco build-tools `maven-release-slim`](https://github.com/Alfresco/alfresco-build-tools)
+
+## Related JIRA
+- [ACS-12085](https://hyland.atlassian.net/browse/ACS-12085)

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>alfresco-java-sdk</artifactId>
     <groupId>org.alfresco</groupId>
-    <version>7.3.4-SNAPSHOT</version>
+    <version>7.3.4-A.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>integration-tests</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>org.alfresco</groupId>
   <artifactId>alfresco-java-sdk</artifactId>
-  <version>7.3.4-SNAPSHOT</version>
+  <version>7.3.4-A.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Alfresco :: Java SDK :: Parent</name>
   <description>Parent for Alfresco Java SDK</description>

--- a/samples/event-api-handlers/pom.xml
+++ b/samples/event-api-handlers/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.alfresco</groupId>
     <artifactId>alfresco-java-sdk-samples</artifactId>
-    <version>7.3.4-SNAPSHOT</version>
+    <version>7.3.4-A.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>event-api-handlers</artifactId>

--- a/samples/event-api-spring-integration/pom.xml
+++ b/samples/event-api-spring-integration/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.alfresco</groupId>
     <artifactId>alfresco-java-sdk-samples</artifactId>
-    <version>7.3.4-SNAPSHOT</version>
+    <version>7.3.4-A.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>event-api-spring-integration</artifactId>

--- a/samples/extension-template/pom.xml
+++ b/samples/extension-template/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.alfresco</groupId>
     <artifactId>alfresco-java-sdk-samples</artifactId>
-    <version>7.3.4-SNAPSHOT</version>
+    <version>7.3.4-A.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>extension-template</artifactId>

--- a/samples/oauth2-feign-sample/pom.xml
+++ b/samples/oauth2-feign-sample/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.alfresco</groupId>
     <artifactId>alfresco-java-sdk-samples</artifactId>
-    <version>7.3.4-SNAPSHOT</version>
+    <version>7.3.4-A.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>oauth2-feign-sample</artifactId>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.alfresco</groupId>
   <artifactId>alfresco-java-sdk-samples</artifactId>
-  <version>7.3.4-SNAPSHOT</version>
+  <version>7.3.4-A.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Alfresco :: Java SDK :: Samples</name>
   <description>Sample application of the Java SDK</description>


### PR DESCRIPTION
This pull request updates the project for the next alpha release cycle by bumping all Maven project versions from `7.3.4-SNAPSHOT` to `7.3.4-A.1-SNAPSHOT` and adds comprehensive documentation for the new automated release process. The documentation details versioning conventions, CI workflow triggers, and step-by-step instructions for releasing both alpha and GA versions.

The most important changes are:

**Release Process Documentation:**
* Added a new `docs/release-process.md` file describing the automated CI-based release process, versioning conventions, and Maven Central/Nexus publishing steps. This includes clear instructions for alpha and GA releases, commit message requirements, and troubleshooting tips.
* Updated the `README.md` to reference the new release process documentation for the Java SDK.

**Version Bump for Next Alpha:**
* Updated the parent and module versions in all `pom.xml` files across the repository from `7.3.4-SNAPSHOT` to `7.3.4-A.1-SNAPSHOT` to prepare for the `7.3.4-A.1` alpha release. This ensures consistency and aligns with the new release process. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L12-R12) [[2]](diffhunk://#diff-56ea14236df2f839ec153d83791ec9c32993ae80dc2ae20418c779b90329d0f3L7-R7) [[3]](diffhunk://#diff-4a944d79c274922d74f23f5b9a0d0ca83f7133b736a35882282234c3207b0f73L8-R8) [[4]](diffhunk://#diff-f3cdb85c51964d050f1128f0fb4e209b842d8529bfd7b12082de29d1dfe439ceL7-R12) [[5]](diffhunk://#diff-2783d50a6fefc08117618a611da5875232123406bc8e6256bd1b2cbd540901d3L8-R8) [[6]](diffhunk://#diff-1eee3e253f62a941203494ae7beeb89bc69fb167a4aacde3ed9c98ff5001eb18L8-R8) [[7]](diffhunk://#diff-5a115bc7f647135aab5d956b07e5604e4e19f811fec337ee446773c8b9dfca2dL8-R8) [[8]](diffhunk://#diff-896007804d91dbd9da89e6c8699bc22d26e4f77d4ff6865c16820cfda0024d71L8-R8) [[9]](diffhunk://#diff-cb094ff010eed7a34993c2e3a88e4b2733efc272794e3da7b93904a2405e6413L8-R8) [[10]](diffhunk://#diff-b30fbe68825fb173cd6f8c0ed614734babfff5d56a0f21b64a8c9f32470ecdccL8-R8) [[11]](diffhunk://#diff-ff77aeeca67ff5a85dba58efa36987b33e3946b1dde5f2a761bf21f729ad2268L8-R8) [[12]](diffhunk://#diff-e0c19b79daff91491e6cb3c350e2be913e4a5627b60e06a5ae91b8cd47d76924L8-R8) [[13]](diffhunk://#diff-3b7c131fb9becff591ff3eb25a6b91b29420703e244fadc2096277504d3a2ae1L8-R8) [[14]](diffhunk://#diff-eb8baa2a7ef27be22bc6fa693b229395e6ae824a95ccde07202d8d97b91f7740L14-R14) [[15]](diffhunk://#diff-f8d5e8b2f721dcce84ddf4c934988be241e45515d3aa7e1abd01db96dab6d388L8-R8) [[16]](diffhunk://#diff-6455416425ab09d470605ec32c192266a56363aed53eda6c5681ffe6ec2a568aL8-R8) [[17]](diffhunk://#diff-26de857b4bcd66958ac110469ccab7c946b3f41bf6207b6bdcc8964e781e2b9eL8-R8) [[18]](diffhunk://#diff-83566aee8c8198ebe2924c7bd93991be1393baf0671211bb6c0fe3ce32a220dbL8-R8)

These changes ensure the project is ready for the next alpha release and provide clear guidance for future releases using the new automated workflow.