### PR TITLE
Fix release workflow by inlining project.build.generatedSourceDirectory property

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,6 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           release-version: ${{ env.RELEASE_VERSION }}
           development-version: ${{ env.DEVELOPMENT_VERSION }}
-          post-version-command: mvn -B -ntp generate-sources -pl alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib -am
           maven-args: >
             -DskipTests
             -DbuildNumber=${{ github.run_number }}

--- a/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib/pom.xml
+++ b/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib/pom.xml
@@ -30,8 +30,9 @@
     <acs.search.api>${project.build.directory}/definitions/alfresco-search.yaml</acs.search.api>
     <acs.search-sql.api>${project.build.directory}/definitions/alfresco-search-sql.yaml</acs.search-sql.api>
   </properties>
-  <!-- Keep "generated" a literal path below and in the swagger-codegen-maven-plugin output configs: a
-       project.build.*-named property here broke the release workflow's `mvn versions:set`/codegen tooling. -->
+  <!-- Keep "generated" a literal path below: a project.build.*-named property here broke the release
+       workflow's `mvn versions:set`. The swagger-codegen-maven-plugin output configs below also hardcode
+       it, just to stay uniform with these module paths. -->
   <modules>
     <module>generated/alfresco-core-rest-api</module>
     <module>generated/alfresco-auth-rest-api</module>

--- a/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib/pom.xml
+++ b/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib/pom.xml
@@ -30,6 +30,8 @@
     <acs.search.api>${project.build.directory}/definitions/alfresco-search.yaml</acs.search.api>
     <acs.search-sql.api>${project.build.directory}/definitions/alfresco-search-sql.yaml</acs.search-sql.api>
   </properties>
+  <!-- Keep "generated" a literal path below and in the swagger-codegen-maven-plugin output configs: a
+       project.build.*-named property here broke the release workflow's `mvn versions:set`/codegen tooling. -->
   <modules>
     <module>generated/alfresco-core-rest-api</module>
     <module>generated/alfresco-auth-rest-api</module>

--- a/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib/pom.xml
+++ b/alfresco-acs-java-rest-api/alfresco-acs-java-rest-api-lib/pom.xml
@@ -14,7 +14,6 @@
   <packaging>pom</packaging>
 
   <properties>
-    <project.build.generatedSourceDirectory>generated</project.build.generatedSourceDirectory>
     <swagger-codegen-maven-plugin.groupId>io.swagger</swagger-codegen-maven-plugin.groupId>
     <swagger-codegen-maven-plugin.version>2.4.30</swagger-codegen-maven-plugin.version>
     <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
@@ -32,14 +31,14 @@
     <acs.search-sql.api>${project.build.directory}/definitions/alfresco-search-sql.yaml</acs.search-sql.api>
   </properties>
   <modules>
-    <module>${project.build.generatedSourceDirectory}/alfresco-core-rest-api</module>
-    <module>${project.build.generatedSourceDirectory}/alfresco-auth-rest-api</module>
-    <module>${project.build.generatedSourceDirectory}/alfresco-discovery-rest-api</module>
-    <module>${project.build.generatedSourceDirectory}/alfresco-governance-core-rest-api</module>
-    <module>${project.build.generatedSourceDirectory}/alfresco-governance-classification-rest-api</module>
-    <module>${project.build.generatedSourceDirectory}/alfresco-model-rest-api</module>
-    <module>${project.build.generatedSourceDirectory}/alfresco-search-rest-api</module>
-    <module>${project.build.generatedSourceDirectory}/alfresco-search-sql-rest-api</module>
+    <module>generated/alfresco-core-rest-api</module>
+    <module>generated/alfresco-auth-rest-api</module>
+    <module>generated/alfresco-discovery-rest-api</module>
+    <module>generated/alfresco-governance-core-rest-api</module>
+    <module>generated/alfresco-governance-classification-rest-api</module>
+    <module>generated/alfresco-model-rest-api</module>
+    <module>generated/alfresco-search-rest-api</module>
+    <module>generated/alfresco-search-sql-rest-api</module>
     <module>alfresco-event-gateway-api-client</module>
   </modules>
   <repositories>
@@ -154,7 +153,7 @@
                   <language>java</language>
                   <library>resttemplate</library>
                   <inputSpec>${acs.auth.api}</inputSpec>
-                  <output>${project.build.generatedSourceDirectory}/alfresco-auth-rest-api</output>
+                  <output>generated/alfresco-auth-rest-api</output>
                   <artifactId>alfresco-core-rest-api</artifactId>
                   <configOptions>
                     <apiPackage>${project.groupId}.authentication.handler</apiPackage>
@@ -170,7 +169,7 @@
                 </goals>
                 <configuration>
                   <inputSpec>${acs.auth.api}</inputSpec>
-                  <output>${project.build.generatedSourceDirectory}/alfresco-auth-rest-api</output>
+                  <output>generated/alfresco-auth-rest-api</output>
                   <artifactId>alfresco-auth-rest-api</artifactId>
                   <configOptions>
                     <apiPackage>${project.groupId}.authentication.handler</apiPackage>
@@ -188,7 +187,7 @@
                   <language>java</language>
                   <library>resttemplate</library>
                   <inputSpec>${acs.core.api}</inputSpec>
-                  <output>${project.build.generatedSourceDirectory}/alfresco-core-rest-api</output>
+                  <output>generated/alfresco-core-rest-api</output>
                   <artifactId>alfresco-core-rest-api</artifactId>
                   <configOptions>
                     <apiPackage>${project.groupId}.core.handler</apiPackage>
@@ -204,7 +203,7 @@
                 </goals>
                 <configuration>
                   <inputSpec>${acs.core.api}</inputSpec>
-                  <output>${project.build.generatedSourceDirectory}/alfresco-core-rest-api</output>
+                  <output>generated/alfresco-core-rest-api</output>
                   <artifactId>alfresco-core-rest-api</artifactId>
                   <configOptions>
                     <apiPackage>${project.groupId}.core.handler</apiPackage>
@@ -222,7 +221,7 @@
                   <language>java</language>
                   <library>resttemplate</library>
                   <inputSpec>${acs.discovery.api}</inputSpec>
-                  <output>${project.build.generatedSourceDirectory}/alfresco-discovery-rest-api</output>
+                  <output>generated/alfresco-discovery-rest-api</output>
                   <artifactId>alfresco-discovery-rest-api</artifactId>
                   <configOptions>
                     <apiPackage>${project.groupId}.discovery.handler</apiPackage>
@@ -238,7 +237,7 @@
                 </goals>
                 <configuration>
                   <inputSpec>${acs.discovery.api}</inputSpec>
-                  <output>${project.build.generatedSourceDirectory}/alfresco-discovery-rest-api</output>
+                  <output>generated/alfresco-discovery-rest-api</output>
                   <artifactId>alfresco-discovery-rest-api</artifactId>
                   <configOptions>
                     <apiPackage>${project.groupId}.discovery.handler</apiPackage>
@@ -256,7 +255,7 @@
                   <language>java</language>
                   <library>resttemplate</library>
                   <inputSpec>${acs.governance-core.api}</inputSpec>
-                  <output>${project.build.generatedSourceDirectory}/alfresco-governance-core-rest-api</output>
+                  <output>generated/alfresco-governance-core-rest-api</output>
                   <artifactId>alfresco-governance-core-rest-api</artifactId>
                   <configOptions>
                     <apiPackage>${project.groupId}.governance.core.handler</apiPackage>
@@ -272,7 +271,7 @@
                 </goals>
                 <configuration>
                   <inputSpec>${acs.governance-core.api}</inputSpec>
-                  <output>${project.build.generatedSourceDirectory}/alfresco-governance-core-rest-api</output>
+                  <output>generated/alfresco-governance-core-rest-api</output>
                   <artifactId>alfresco-governance-core-rest-api</artifactId>
                   <configOptions>
                     <apiPackage>${project.groupId}.governance.core.handler</apiPackage>
@@ -290,7 +289,7 @@
                   <language>java</language>
                   <library>resttemplate</library>
                   <inputSpec>${acs.governance-classification.api}</inputSpec>
-                  <output>${project.build.generatedSourceDirectory}/alfresco-governance-classification-rest-api</output>
+                  <output>generated/alfresco-governance-classification-rest-api</output>
                   <artifactId>alfresco-governance-classification-rest-api</artifactId>
                   <configOptions>
                     <apiPackage>${project.groupId}.governance.classification.handler</apiPackage>
@@ -306,7 +305,7 @@
                 </goals>
                 <configuration>
                   <inputSpec>${acs.governance-classification.api}</inputSpec>
-                  <output>${project.build.generatedSourceDirectory}/alfresco-governance-classification-rest-api</output>
+                  <output>generated/alfresco-governance-classification-rest-api</output>
                   <artifactId>alfresco-governance-classification-rest-api</artifactId>
                   <configOptions>
                     <apiPackage>${project.groupId}.governance.classification.handler</apiPackage>
@@ -324,7 +323,7 @@
                   <language>java</language>
                   <library>resttemplate</library>
                   <inputSpec>${acs.model.api}</inputSpec>
-                  <output>${project.build.generatedSourceDirectory}/alfresco-model-rest-api</output>
+                  <output>generated/alfresco-model-rest-api</output>
                   <artifactId>alfresco-model-rest-api</artifactId>
                   <configOptions>
                     <apiPackage>${project.groupId}.model.handler</apiPackage>
@@ -340,7 +339,7 @@
                 </goals>
                 <configuration>
                   <inputSpec>${acs.model.api}</inputSpec>
-                  <output>${project.build.generatedSourceDirectory}/alfresco-model-rest-api</output>
+                  <output>generated/alfresco-model-rest-api</output>
                   <artifactId>alfresco-model-rest-api</artifactId>
                   <configOptions>
                     <apiPackage>${project.groupId}.model.handler</apiPackage>
@@ -358,7 +357,7 @@
                   <language>java</language>
                   <library>resttemplate</library>
                   <inputSpec>${acs.search.api}</inputSpec>
-                  <output>${project.build.generatedSourceDirectory}/alfresco-search-rest-api</output>
+                  <output>generated/alfresco-search-rest-api</output>
                   <artifactId>alfresco-search-rest-api</artifactId>
                   <configOptions>
                     <apiPackage>${project.groupId}.search.handler</apiPackage>
@@ -374,7 +373,7 @@
                 </goals>
                 <configuration>
                   <inputSpec>${acs.search.api}</inputSpec>
-                  <output>${project.build.generatedSourceDirectory}/alfresco-search-rest-api</output>
+                  <output>generated/alfresco-search-rest-api</output>
                   <artifactId>alfresco-search-rest-api</artifactId>
                   <configOptions>
                     <apiPackage>${project.groupId}.search.handler</apiPackage>
@@ -392,7 +391,7 @@
                   <language>java</language>
                   <library>resttemplate</library>
                   <inputSpec>${acs.search-sql.api}</inputSpec>
-                  <output>${project.build.generatedSourceDirectory}/alfresco-search-sql-rest-api</output>
+                  <output>generated/alfresco-search-sql-rest-api</output>
                   <artifactId>alfresco-search-sql-rest-api</artifactId>
                   <configOptions>
                     <apiPackage>${project.groupId}.search.sql.handler</apiPackage>
@@ -408,7 +407,7 @@
                 </goals>
                 <configuration>
                   <inputSpec>${acs.search-sql.api}</inputSpec>
-                  <output>${project.build.generatedSourceDirectory}/alfresco-search-sql-rest-api</output>
+                  <output>generated/alfresco-search-sql-rest-api</output>
                   <artifactId>alfresco-search-sql-rest-api</artifactId>
                   <configOptions>
                     <apiPackage>${project.groupId}.search.sql.handler</apiPackage>


### PR DESCRIPTION
## Summary
- Fix the release workflow: `project.build.generatedSourceDirectory` shadowed a Maven built-in naming convention and only ever resolved to the literal string `generated`, so inline it directly into the module paths and swagger-codegen-maven-plugin output configs in `alfresco-acs-java-rest-api-lib/pom.xml`.
- Drop the `post-version-command` from the release workflow's `maven-release-slim` step — it re-ran `generate-sources` after the version bump to work around the property not resolving correctly there, but `versions:set` was verified to already update the `generated/*/pom.xml` files during the bump on its own, making the extra step redundant.

## Test plan
- [x] Ran `mvn versions:set -DnewVersion=... -DgenerateBackupPoms=false` from the repo root and confirmed all `generated/*/pom.xml` files (and every other reactor module) picked up the new version, then reverted back to `7.3.4-A.2-SNAPSHOT`.