### PR TITLE
sample exclusion in release step for handling Failed to execute goal 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,11 +124,13 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           release-version: ${{ env.RELEASE_VERSION }}
           development-version: ${{ env.DEVELOPMENT_VERSION }}
+          release-profile: sdk-release
           maven-args: >
             -DskipTests
             -DbuildNumber=${{ github.run_number }}
             -Dags.version=${{ env.AGS_VERSION }}
             -Dacs.version=${{ env.ACS_VERSION }}
+            -pl '!samples,!samples/extension-template,!samples/event-api-handlers,!samples/event-api-spring-integration,!samples/oauth2-feign-sample,!integration-tests'
 
   publish_to_maven_central:
     name: "Publish to Maven Central"


### PR DESCRIPTION
sample exclusion in release step for handling Failed to execute goal
This pull request makes a targeted update to the CI workflow configuration, specifically for the Maven release job. The changes improve the release process by specifying a custom release profile and excluding certain modules from the build.

Key workflow configuration updates:

**Maven Release Process:**

* Adds the `release-profile: sdk-release` parameter to the Maven release job, ensuring that the build uses the appropriate Maven profile for SDK releases.
* Updates the `maven-args` to exclude specific modules (`samples`, `samples/extension-template`, `samples/event-api-handlers`, `samples/event-api-spring-integration`, `samples/oauth2-feign-sample`, and `integration-tests`) from the release build, streamlining the release process and avoiding unnecessary builds of sample and integration test modules.