### PR TITLE
AAE-50661 Bump spring-boot to 4.0.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>4.0.7</version>
+    <version>4.0.8</version>
     <relativePath />
   </parent>
   <groupId>org.alfresco</groupId>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>4.0.7</version>
+    <version>4.0.8</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
This will resolve to version 2.25.5 of log4j-api, which should fix the security vulnerability "improper encoding of non-finite floating-point values during MapMessage JSON serialization."

https://hyland.atlassian.net/browse/AAE-50661